### PR TITLE
Control-char handling

### DIFF
--- a/Decode/EventHeaderEnumerator.cs
+++ b/Decode/EventHeaderEnumerator.cs
@@ -757,7 +757,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///                 DoSimpleArrayElement(item, i);
         ///             }
         ///             DoSimpleArrayEnd(item);
-        /// 
+        ///
         ///             // Skip the entire array at once.
         ///             if (!e.MoveNextSibling()) // Instead of MoveNext().
         ///             {
@@ -770,7 +770,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///         DoComplexArrayEnd(item);
         ///         break;
         ///     }
-        /// 
+        ///
         ///     if (!e.MoveNext())
         ///     {
         ///         return e.LastError;
@@ -1234,11 +1234,11 @@ namespace Microsoft.LinuxTracepoints.Decode
             Debug.Assert(m_eventData.Length == eventDataSpan.Length);
 
             sb.Append('"');
-            PerfConvert.AppendEscapedJson(
+            PerfConvert.StringAppendWithControlCharsJsonEscape(
                 sb,
                 m_tracepointName.AsSpan().Slice(0, m_tracepointName.LastIndexOf('_')));
             sb.Append(':');
-            PerfConvert.AppendEscapedJson(
+            PerfConvert.StringAppendWithControlCharsJsonEscape(
                 sb,
                 eventDataSpan.Slice(m_metaBegin, m_eventNameSize),
                 Text.Encoding.UTF8);

--- a/Decode/EventHeaderItemInfo.cs
+++ b/Decode/EventHeaderItemInfo.cs
@@ -88,7 +88,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// </summary>
         public StringBuilder AppendAsString(StringBuilder sb)
         {
-            PerfConvert.StringAppend(sb, this.NameBytes, Encoding.UTF8);
+            PerfConvert.StringAppendWithControlCharsJsonEscape(sb, this.NameBytes, Encoding.UTF8);
 
             var fieldTag = this.Value.Type.FieldTag;
             if (fieldTag == 0)

--- a/Decode/JsonWriter.cs
+++ b/Decode/JsonWriter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.LinuxTracepoints.Decode
             this.CommaSpace();
             this.builder.Append('"');
 
-            PerfConvert.AppendEscapedJson(this.builder, nameUtf8, Text.Encoding.UTF8);
+            PerfConvert.StringAppendWithControlCharsJsonEscape(this.builder, nameUtf8, Text.Encoding.UTF8);
             if (this.wantFieldTag && fieldTag != 0)
             {
                 this.builder.Append(";tag=");

--- a/Decode/PerfConvertOptions.cs
+++ b/Decode/PerfConvertOptions.cs
@@ -83,6 +83,24 @@ namespace Microsoft.LinuxTracepoints.Decode
         ErrnoUnknownAsString = 0x800,
 
         /// <summary>
+        /// For non-JSON string conversions: replace control characters with space.
+        /// Conflicts with StringControlCharsJsonEscape.
+        /// </summary>
+        StringControlCharsReplaceWithSpace = 0x10000,
+
+        /// <summary>
+        /// For non-JSON string conversions: escape control characters using JSON-compatible
+        /// escapes sequences, e.g. "\n" for newline or "\u0000" for NUL.
+        /// Conflicts with StringControlCharsReplaceWithSpace.
+        /// </summary>
+        StringControlCharsJsonEscape = 0x20000,
+
+        /// <summary>
+        /// Mask for string control character flags.
+        /// </summary>
+        StringControlCharsMask = StringControlCharsReplaceWithSpace | StringControlCharsJsonEscape,
+
+        /// <summary>
         /// Default flags.
         /// </summary>
         Default =
@@ -96,7 +114,8 @@ namespace Microsoft.LinuxTracepoints.Decode
             UnixTimeWithinRangeAsString |
             UnixTimeOutOfRangeAsString |
             ErrnoKnownAsString |
-            ErrnoUnknownAsString,
+            ErrnoUnknownAsString |
+            StringControlCharsReplaceWithSpace,
 
         /// <summary>
         /// All flags set.

--- a/Decode/PerfDataFileReader.cs
+++ b/Decode/PerfDataFileReader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <summary>
         /// ReadEvent:
         /// No more events because the file contains invalid data.
-        /// 
+        ///
         /// GetSampleEventInfo or GetNonSampleEventInfo:
         /// Failed to get event info because the event contains invalid data.
         /// </summary>
@@ -423,7 +423,7 @@ namespace Microsoft.LinuxTracepoints.Decode
             GC.SuppressFinalize(this);
 
             FileClose();
-            
+
             foreach (var item in m_buffers)
             {
                 item.Dispose(); // Return buffer to ArrayPool.
@@ -532,12 +532,12 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// Closes the current input file (if any), then opens the specified
         /// perf.data file (Mode = Open, Access = Read, Share = Read + Delete) and
         /// reads the file header.
-        /// 
+        ///
         /// If not a pipe-mode file, loads headers/attributes.
-        /// 
+        ///
         /// If a pipe-mode file, headers and attributes will be loaded as the header
         /// events are encountered by ReadEvent.
-        /// 
+        ///
         /// On successful return, the file will be positioned before the first event.
         /// </summary>
         /// <returns>true on success, false if the file is not a valid perf.data file.</returns>
@@ -563,12 +563,12 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <summary>
         /// Closes the current input file (if any), then opens the specified stream
         /// and reads the file header.
-        /// 
+        ///
         /// If reading a pipe-mode file, headers will be loaded as the header
         /// events are encountered by ReadEvent. No seeking will occur.
-        /// 
+        ///
         /// If not a pipe-mode file, loads headers. The stream must be seekable.
-        /// 
+        ///
         /// On successful return, the file will be positioned before the first event.
         /// </summary>
         /// <param name="stream">

--- a/Decode/PerfEventAbi.cs
+++ b/Decode/PerfEventAbi.cs
@@ -699,14 +699,14 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <summary>
         /// sample_regs_user:
         /// Defines set of user regs to dump on samples.
-        /// See asm/perf_regs.h for details.  
+        /// See asm/perf_regs.h for details.
         /// </summary>
         [FieldOffset(80)]
         public UInt64 SampleRegsUser;
 
         /// <summary>
         /// sample_stack_user:
-        /// Defines size of the user stack to dump on samples.  
+        /// Defines size of the user stack to dump on samples.
         /// </summary>
         [FieldOffset(88)]
         public UInt32 SampleStackUser;
@@ -732,7 +732,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// aux_watermark:
-        /// Wakeup watermark for AUX area 
+        /// Wakeup watermark for AUX area
         /// </summary>
         [FieldOffset(104)]
         public UInt32 AuxWatermark;
@@ -843,7 +843,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <code><![CDATA[
         /// struct {
         ///    struct perf_event_header    header;
-        /// 
+        ///
         ///    u32                pid, tid;
         ///    u64                addr;
         ///    u64                len;
@@ -873,7 +873,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <code><![CDATA[
         /// struct {
         ///    struct perf_event_header    header;
-        /// 
+        ///
         ///    u32                pid, tid;
         ///    char                comm[];
         ///     struct sample_id        sample_id;
@@ -944,7 +944,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// struct {
         ///    struct perf_event_header    header;
         ///    u32                pid, tid;
-        /// 
+        ///
         ///    struct read_format        values;
         ///     struct sample_id        sample_id;
         /// };
@@ -957,13 +957,13 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <code><![CDATA[
         /// struct {
         ///    struct perf_event_header    header;
-        /// 
+        ///
         ///    #
         ///    # Note that PERF_SAMPLE_IDENTIFIER duplicates PERF_SAMPLE_ID.
         ///    # The advantage of PERF_SAMPLE_IDENTIFIER is that its position
         ///    # is fixed relative to header.
         ///    #
-        /// 
+        ///
         ///    { u64            id;      } && PERF_SAMPLE_IDENTIFIER
         ///    { u64            ip;      } && PERF_SAMPLE_IP
         ///    { u32            pid, tid; } && PERF_SAMPLE_TID
@@ -973,12 +973,12 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///    { u64            stream_id;} && PERF_SAMPLE_STREAM_ID
         ///    { u32            cpu, res; } && PERF_SAMPLE_CPU
         ///    { u64            period;   } && PERF_SAMPLE_PERIOD
-        /// 
+        ///
         ///    { struct read_format    values;      } && PERF_SAMPLE_READ
-        /// 
+        ///
         ///    { u64            nr,
         ///      u64            ips[nr];  } && PERF_SAMPLE_CALLCHAIN
-        /// 
+        ///
         ///    #
         ///    # The RAW record below is opaque data wrt the ABI
         ///    #
@@ -989,22 +989,22 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///    #
         ///    # In other words, PERF_SAMPLE_RAW contents are not an ABI.
         ///    #
-        /// 
+        ///
         ///    { u32            size;
         ///      char                  data[size];}&& PERF_SAMPLE_RAW
-        /// 
+        ///
         ///    { u64                   nr;
         ///      { u64    hw_idx; } && PERF_SAMPLE_BRANCH_HW_INDEX
         ///        { u64 from, to, flags } lbr[nr];
         ///      } && PERF_SAMPLE_BRANCH_STACK
-        /// 
+        ///
         ///     { u64            abi; # enum perf_sample_regs_abi
         ///       u64            regs[weight(mask)]; } && PERF_SAMPLE_REGS_USER
-        /// 
+        ///
         ///     { u64            size;
         ///       char            data[size];
         ///       u64            dyn_size; } && PERF_SAMPLE_STACK_USER
-        /// 
+        ///
         ///    { union perf_sample_weight
         ///     {
         ///        u64        full; && PERF_SAMPLE_WEIGHT
@@ -1044,7 +1044,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <code><![CDATA[
         /// struct {
         ///    struct perf_event_header    header;
-        /// 
+        ///
         ///    u32                pid, tid;
         ///    u64                addr;
         ///    u64                len;
@@ -1073,12 +1073,12 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_AUX:
-        /// 
+        ///
         /// Records that new data landed in the AUX buffer part.
         /// <code><![CDATA[
         /// struct {
         ///     struct perf_event_header    header;
-        /// 
+        ///
         ///     u64                aux_offset;
         ///     u64                aux_size;
         ///    u64                flags;
@@ -1090,7 +1090,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_ITRACE_START:
-        /// 
+        ///
         /// Indicates that instruction trace has started
         /// <code><![CDATA[
         /// struct {
@@ -1105,12 +1105,12 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_LOST_SAMPLES:
-        /// 
+        ///
         /// Records the dropped/lost sample number.
         /// <code><![CDATA[
         /// struct {
         ///    struct perf_event_header    header;
-        /// 
+        ///
         ///    u64                lost;
         ///    struct sample_id        sample_id;
         /// };
@@ -1120,7 +1120,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_SWITCH:
-        /// 
+        ///
         /// Records a context switch in or out (flagged by
         /// PERF_RECORD_MISC_SWITCH_OUT). See also
         /// PERF_RECORD_SWITCH_CPU_WIDE.
@@ -1135,7 +1135,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_SWITCH_CPU_WIDE:
-        /// 
+        ///
         /// CPU-wide version of PERF_RECORD_SWITCH with next_prev_pid and
         /// next_prev_tid that are the next (switching out) or previous
         /// (switching in) pid/tid.
@@ -1167,7 +1167,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_KSYMBOL:
-        /// 
+        ///
         /// Record ksymbol register/unregister events:
         /// <code><![CDATA[
         /// struct {
@@ -1185,7 +1185,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_BPF_EVENT:
-        /// 
+        ///
         /// Record bpf events:
         /// <code><![CDATA[
         ///  enum perf_bpf_event_type {
@@ -1193,7 +1193,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///    PERF_BPF_EVENT_PROG_LOAD    = 1,
         ///    PERF_BPF_EVENT_PROG_UNLOAD    = 2,
         ///  };
-        /// 
+        ///
         /// struct {
         ///    struct perf_event_header    header;
         ///    u16                type;
@@ -1221,7 +1221,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_TEXT_POKE:
-        /// 
+        ///
         /// Records changes to kernel text i.e. self-modified code. 'old_len' is
         /// the number of old bytes, 'new_len' is the number of new bytes. Either
         /// 'old_len' or 'new_len' may be zero to indicate, for example, the
@@ -1242,7 +1242,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_AUX_OUTPUT_HW_ID:
-        /// 
+        ///
         /// Data written to the AUX area by hardware due to aux_output, may need
         /// to be matched to the event by an architecture-specific hardware ID.
         /// This records the hardware ID, but requires sample_id to provide the
@@ -1284,12 +1284,12 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// PERF_RECORD_HEADER_EVENT_TYPE: deprecated
         /// <code><![CDATA[
         /// #define MAX_EVENT_NAME 64
-        /// 
+        ///
         /// struct perf_trace_event_type {
         ///     UInt64    event_id;
         ///     char    name[MAX_EVENT_NAME];
         /// };
-        /// 
+        ///
         /// struct event_type_event {
         ///     struct perf_event_header header;
         ///     struct perf_trace_event_type event_type;
@@ -1311,21 +1311,21 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_HEADER_BUILD_ID:
-        /// 
+        ///
         /// Define a ELF build ID for a referenced executable.
         /// </summary>
         HeaderBuildId = 67,
 
         /// <summary>
         /// PERF_RECORD_FINISHED_ROUND:
-        /// 
+        ///
         /// No event reordering over this header. No payload.
         /// </summary>
         FinishedRound = 68,
 
         /// <summary>
         /// PERF_RECORD_ID_INDEX:
-        /// 
+        ///
         /// Map event ids to CPUs and TIDs.
         /// <code><![CDATA[
         /// struct id_index_entry {
@@ -1334,7 +1334,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///     UInt64 cpu;
         ///     UInt64 tid;
         /// };
-        /// 
+        ///
         /// struct id_index_event {
         ///     struct perf_event_header header;
         ///     UInt64 nr;
@@ -1346,7 +1346,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_AUXTRACE_INFO:
-        /// 
+        ///
         /// Auxtrace type specific information. Describe me
         /// <code><![CDATA[
         /// struct auxtrace_info_event {
@@ -1361,7 +1361,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_AUXTRACE:
-        /// 
+        ///
         /// Defines auxtrace data. Followed by the actual data. The contents of
         /// the auxtrace data is dependent on the event and the CPU. For example
         /// for Intel Processor Trace it contains Processor Trace data generated
@@ -1377,7 +1377,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         ///      UInt32 cpu;
         ///      UInt32 reserved__; // For alignment
         /// };
-        /// 
+        ///
         /// struct aux_event {
         ///      struct perf_event_header header;
         ///      UInt64    aux_offset;
@@ -1390,16 +1390,16 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_AUXTRACE_ERROR:
-        /// 
+        ///
         /// Describes an error in hardware tracing
         /// <code><![CDATA[
         /// enum auxtrace_error_type {
         ///     PERF_AUXTRACE_ERROR_ITRACE  = 1,
         ///     PERF_AUXTRACE_ERROR_MAX
         /// };
-        /// 
+        ///
         /// #define MAX_AUXTRACE_ERROR_MSG 64
-        /// 
+        ///
         /// struct auxtrace_error_event {
         ///     struct perf_event_header header;
         ///     UInt32 type;
@@ -1452,7 +1452,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_HEADER_FEATURE:
-        /// 
+        ///
         /// Describes a header feature. These are records used in pipe-mode that
         /// contain information that otherwise would be in perf.data file's header.
         /// </summary>
@@ -1474,7 +1474,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// PERF_RECORD_FINISHED_INIT:
-        /// 
+        ///
         /// Marks the end of records for the system, pre-existing threads in system wide
         /// sessions, etc. Those are the ones prefixed PERF_RECORD_USER_*.
         ///
@@ -1676,14 +1676,14 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// perf_event_header::misc:
-        /// 
+        ///
         /// The misc field contains additional information about the sample.
         /// </summary>
         public PerfEventHeaderMisc Misc;
 
         /// <summary>
         /// perf_event_header::size:
-        /// 
+        ///
         /// This indicates the size of the record.
         /// </summary>
         public UInt16 Size;

--- a/Decode/PerfEventFormat.cs
+++ b/Decode/PerfEventFormat.cs
@@ -118,7 +118,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <summary>
         /// Parses an event's "format" file and sets the fields of this object based
         /// on the results.
-        /// 
+        ///
         /// If "ID:" is a valid unsigned and and "name:" is not empty, returns a new
         /// PerfEventFormat. Otherwise, returns null.
         /// </summary>

--- a/Decode/PerfItemType.cs
+++ b/Decode/PerfItemType.cs
@@ -14,7 +14,7 @@ namespace Microsoft.LinuxTracepoints.Decode
     /// Scalar (non-array field, or one element of an array field):
     /// ElementCount is 1.
     /// TypeSize is the size of the item's type (itemValue.Bytes.Length == TypeSize) if
-    /// the type has a constant size (e.g. a UInt32), or 0 if the type is variable-size 
+    /// the type has a constant size (e.g. a UInt32), or 0 if the type is variable-size
     /// (e.g. a string).
     /// Format is significant.
     /// StructFieldCount should be ignored.

--- a/DecodePerfToJson/DecodePerfToJson.csproj
+++ b/DecodePerfToJson/DecodePerfToJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Common.proj" />
-  
+
   <PropertyGroup>
     <PackAsTool>True</PackAsTool>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DecodeTest/JsonStringWriter.cs
+++ b/DecodeTest/JsonStringWriter.cs
@@ -18,7 +18,7 @@
             this.indentLevel = 0;
             this.comma = false;
         }
-        
+
         public StringBuilder Builder => this.builder;
 
         public void Reset()

--- a/DecodeTest/TextCompare.cs
+++ b/DecodeTest/TextCompare.cs
@@ -40,7 +40,7 @@
             var expectedLines = expectedText.Split(LineSplitChars, StringSplitOptions.RemoveEmptyEntries);
 
             Assert.AreEqual(expectedLines.Length, actualLines.Length);
-            
+
             bool anyDifferences = false;
             for (var i = 0; i < expectedLines.Length; i++)
             {

--- a/DecodeWpa/DecodeWpa.csproj
+++ b/DecodeWpa/DecodeWpa.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Performance.SDK" Version="1.1.13" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <ProjectReference Include="..\Decode\Decode.csproj" />
   </ItemGroup>

--- a/DecodeWpa/PerfDataFormatter.cs
+++ b/DecodeWpa/PerfDataFormatter.cs
@@ -357,7 +357,10 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
         /// <br/>
         /// This method is thread-safe (serialized).
         /// </summary>
-        public KeyValuePair<string, string>[] MakeRowSynchronized(PerfDataEvent perfEvent, int maxTopLevelFields)
+        public KeyValuePair<string, string>[] MakeRowSynchronized(
+            PerfDataEvent perfEvent,
+            int maxTopLevelFields,
+            PerfConvertOptions convertOptions = PerfConvertOptions.Default)
         {
             if (maxTopLevelFields <= 0 || perfEvent.TopLevelFieldCount <= 0)
             {
@@ -423,7 +426,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
 
                             if (this.enumerator.State == EventHeaderEnumeratorState.Value)
                             {
-                                item.Value.AppendScalarTo(sb);
+                                item.Value.AppendScalarTo(sb, convertOptions);
                                 this.enumerator.MoveNext(userSpan);
                             }
                             else
@@ -432,7 +435,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
                                     userSpan,
                                     sb,
                                     false,
-                                    PerfConvertOptions.Default & ~PerfConvertOptions.RootName);
+                                    convertOptions & ~PerfConvertOptions.RootName);
                             }
 
                             row[fieldIndex] = new KeyValuePair<string, string>(
@@ -456,7 +459,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
                         sb.Clear();
                         do
                         {
-                            comma = this.enumerator.AppendJsonItemToAndMoveNextSibling(userSpan, sb, comma);
+                            comma = this.enumerator.AppendJsonItemToAndMoveNextSibling(userSpan, sb, comma, convertOptions);
                         } while (this.enumerator.State > EventHeaderEnumeratorState.BeforeFirstItem);
 
                         row[fieldIndex] = new KeyValuePair<string, string>("...", this.BuilderIntern());
@@ -482,11 +485,11 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
                     sb.Clear();
                     if (fieldVal.Type.IsArrayOrElement)
                     {
-                        fieldVal.AppendScalarTo(sb, PerfConvertOptions.Default & ~PerfConvertOptions.RootName);
+                        fieldVal.AppendSimpleArrayTo(sb, convertOptions);
                     }
                     else
                     {
-                        fieldVal.AppendScalarTo(sb, PerfConvertOptions.Default & ~PerfConvertOptions.RootName);
+                        fieldVal.AppendScalarTo(sb, convertOptions);
                     }
 
                     row[fieldIndex] = new KeyValuePair<string, string>(field.Name, this.BuilderIntern());
@@ -516,7 +519,7 @@ namespace Microsoft.Performance.Toolkit.Plugins.PerfDataExtension
 
                     comma = true;
                     var field = fields[i];
-                    this.AppendFieldAsJson(byteReader, rawData, field, PerfConvertOptions.Default);
+                    this.AppendFieldAsJson(byteReader, rawData, field, convertOptions);
                 }
 
                 row[fieldIndex] = new KeyValuePair<string, string>("...", this.BuilderIntern());


### PR DESCRIPTION
Goal: nicely handle strings with control characters

- Add PerfConvertOptions flags for how to handle control characters. If no flags are present, they pass-through. Other options are replace with space and JSON-escape. Default is replace with space.
- StringAppend method deleted, replaced with StringAppendWithControlChars (takes control char handling as a parameter) and StringAppendWithControlCharsJsonEscape (control chars are JSON-escaped). This forces callers to affirmatively declare how they want to handle control chars in all scenarios.
- Make some previously-private conversion/escaping methods public: Char16AppendWithControlChars, Char16AppendWithControlCharsJsonEscape, etc.
- Fix some cases where control chars were incorrectly passing through.
- Fix arrays in non-EventHeader fields.
- Fix details view when event is corrupt (i.e. when field name is null) or when event name is all whitespace.