### PR TITLE
Decode - handle missing EventDesc

### DIFF
--- a/Decode/PerfNonSampleEventInfo.cs
+++ b/Decode/PerfNonSampleEventInfo.cs
@@ -112,7 +112,7 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         /// <summary>
         /// Event's full name (including the system name), e.g. "dummy:HG",
-        /// or "" if not available.
+        /// or "" if PERF_HEADER_EVENT_DESC header was not available.
         /// </summary>
         public readonly string Name => this.EventDesc.Name;
 
@@ -122,7 +122,8 @@ namespace Microsoft.LinuxTracepoints.Decode
         public readonly PerfTimeSpec TimeSpec => this.SessionInfo.TimeToTimeSpec(this.Time);
 
         /// <summary>
-        /// Returns the full name of the event, e.g. "dummy:HG", or "" if not available.
+        /// Event's full name (including the system name), e.g. "dummy:HG",
+        /// or "" if PERF_HEADER_EVENT_DESC header was not available.
         /// </summary>
         public readonly override string ToString()
         {
@@ -177,7 +178,8 @@ namespace Microsoft.LinuxTracepoints.Decode
                 this.Cpu,
                 this.Pid,
                 this.Tid,
-                this.Name);
+                this.Name,
+                null);
         }
     }
 }

--- a/DecodePerfToJson/PerfToJson.cs
+++ b/DecodePerfToJson/PerfToJson.cs
@@ -166,7 +166,7 @@ namespace DecodePerfToJson
                         // Non-EventHeader decoding.
                         if (this.InfoOptions.HasFlag(PerfInfoOptions.N))
                         {
-                            this.JsonWriter.WriteString("n", sampleEventInfo.Name);
+                            this.JsonWriter.WriteString("n", sampleEventInfo.GetName()); // Garbage
                         }
 
                         // Write the event fields. Skip the common fields by default.
@@ -396,7 +396,7 @@ namespace DecodePerfToJson
                 info.Cpu,
                 info.Pid,
                 info.Tid,
-                showProviderEvent ? info.Name : null);
+                showProviderEvent ? info.GetName() : null); // Garbage
         }
 
         /// <summary>
@@ -469,8 +469,8 @@ namespace DecodePerfToJson
                 ReadOnlySpan<char> providerName, eventName;
                 if (colonPos < 0)
                 {
-                    providerName = default;
-                    eventName = nameSpan;
+                    providerName = nameSpan;
+                    eventName = default;
                 }
                 else
                 {

--- a/DecodeSample/DataToWriter.cs
+++ b/DecodeSample/DataToWriter.cs
@@ -101,7 +101,7 @@ namespace DecodeSample
                         continue; // Usually can't make use of the event without the metadata.
                     }
 
-                    this.writer.WriteLine($"Sample: {sampleEventInfo.Name}");
+                    this.writer.WriteLine($"Sample: {sampleEventInfo.GetName()}");
                     this.writer.WriteLine($"  size = {eventBytes.Header.Size}");
 
                     // Found event info (attributes). Include data from it in the output.


### PR DESCRIPTION
It is possible for a perf.data file to omit the EventDesc header. If that happens, it means we can't get the event's name (e.g. "user_events:MyEvent") from it.

This is most significant for Sample events. Most Sample events are tracepoints, and tracepoints have associated format metadata, and the format metadata contains the SystemName and TracepointName.

Since the event name for tracepoints is "SystemName:TracepointName", we can get the event name from either EventDesc header or format metadata. Fix the Decode library to make that easier.

PerfEventDesc.cs:
- Slightly unrelated, don't accept null for the ids parameter.
- Slightly unrelated, the only caller of the private EmptyIds property is now the Empty property, so inline it.
- Update comments to explain when the Name property might be empty.
- Add GetName() method that can get the name from either the EventDesc header or the format metadata.
- Change ToString() to use GetName().

PerfNonSampleEventInfo.cs:
- Update comments to explain when the Name property might be empty.

PerfSampleEventInfo.cs:
- Update comments to explain when the Name property might be empty.
- Change ToString() to use eventDesc.GetName() instead of eventDesc.Name.
- Add a GetName() method that returns eventDesc.GetName().
- AppendJsonEventIdentityTo can now fall back to format metadata for name.
- AppendJsonEventInfoTo can now fall back to format metadata for name.

PerfSessionInfo.cs:
- AppendJsonEventInfoTo can now fall back to format metadata for name.
- In the unexpected case when event name is present in EventDesc but contains no colon character, put the name in the provider part instead of the event part.

PerfToJson.cs:
- Use GetName() so that we get the name from Format if not available from EventDesc.
- In the unexpected case when event name is present in EventDesc but contains no colon character, put the name in the provider part instead of the event part.

DataToWriter.cs:
- Use GetName() so that we get the name from Format if not available from EventDesc.