### PR TITLE
Use CSharp language version 12

### DIFF
--- a/Common.proj
+++ b/Common.proj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
 
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <WarningLevel>9999</WarningLevel>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>

--- a/Decode/PerfDataFileReader.cs
+++ b/Decode/PerfDataFileReader.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <param name="info">Receives event information.</param>
         /// <returns>Ok on success, other value if this event could not be decoded.</returns>
         public PerfDataFileResult GetSampleEventInfo(
-            in PerfEventBytes eventBytes,
+            PerfEventBytes eventBytes,
             out PerfSampleEventInfo info)
         {
             PerfDataFileResult result;
@@ -1368,7 +1368,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// <param name="info">Receives event information.</param>
         /// <returns>Ok on success, other value if this event could not be decoded.</returns>
         public PerfDataFileResult GetNonSampleEventInfo(
-            in PerfEventBytes eventBytes,
+            PerfEventBytes eventBytes,
             out PerfNonSampleEventInfo info)
         {
             PerfDataFileResult result;


### PR DESCRIPTION
Update to CSharp version 12.

Doing this reveals that newly-enforced validation for tracking lifetimes doesn't allow passing passing the PerfEventBytes struct by `in` ref without marking the caller as `unsafe`. We don't want the caller to have to be unsafe, so fix. I'm not entirely sure why this is disallowed, but the `in` was just a minor performance optimization, so just remove it.