### PR TITLE
Provider - prototype support for generating events

### DIFF
--- a/LinuxTracepoints-Net.sln
+++ b/LinuxTracepoints-Net.sln
@@ -34,6 +34,10 @@ Project("{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}") = "wpa", "C:\Program Files (x8
 		IORedirection = Auto
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Provider", "Provider\Provider.csproj", "{B3C34C8F-C9E8-4FD2-8E6C-59A358D64C01}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProviderSample", "ProviderSample\ProviderSample.csproj", "{DD16875B-C2E2-4DF7-B9A5-320F13048B23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +66,14 @@ Global
 		{F0A5B56F-16A7-4151-9A19-26BD20DA8D5D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D31B2680-10FB-4E19-A6AC-91A4A02601C4}.Debug|Any CPU.ActiveCfg = Release|Any CPU
 		{D31B2680-10FB-4E19-A6AC-91A4A02601C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3C34C8F-C9E8-4FD2-8E6C-59A358D64C01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3C34C8F-C9E8-4FD2-8E6C-59A358D64C01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3C34C8F-C9E8-4FD2-8E6C-59A358D64C01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3C34C8F-C9E8-4FD2-8E6C-59A358D64C01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD16875B-C2E2-4DF7-B9A5-320F13048B23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD16875B-C2E2-4DF7-B9A5-320F13048B23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD16875B-C2E2-4DF7-B9A5-320F13048B23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD16875B-C2E2-4DF7-B9A5-320F13048B23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Provider/DataSegment.cs
+++ b/Provider/DataSegment.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.LinuxTracepoints.Provider;
+
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct DataSegment
+{
+    public void* PinnedBase;
+    public nuint Length;
+
+    public DataSegment(void* pinnedBase, nuint length)
+    {
+        this.PinnedBase = pinnedBase;
+        this.Length = length;
+    }
+}

--- a/Provider/PerfTracepoint.cs
+++ b/Provider/PerfTracepoint.cs
@@ -1,0 +1,405 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.LinuxTracepoints.Provider;
+
+using System;
+
+/// <summary>
+/// Represents a user_events tracepoint. The tracepoint is registered by the constructor.
+/// You'll generally construct all of your application's Tracepoint objects at application
+/// start or component initialization. You'll use the IsEnabled property to determine
+/// whether any sessions are collecting the tracecpoint, and you'll use the Write method
+/// to write events.
+/// <br/>
+/// For more information, see https://docs.kernel.org/trace/user_events.html.
+/// <br/>
+/// Normal usage:
+/// <code>
+/// Tracepoint tp = new Tracepoint("MyEventName int MyField1; int MyField2");
+/// 
+/// // To log an event where preparing the data is very simple:
+/// tp.Write(data...);
+/// 
+/// // To log an event where preparing the data is expensive:
+/// if (tp.IsEnabled) // Skip preparing data and calling Write if the tracepoint is not enabled.
+/// {
+///     var data = ...; // Prepare data that needs to be logged.
+///     tp.Write(data...);
+/// }
+/// </code>
+/// Note that tracepoint registration can fail, and Write operations can also fail.
+/// The RegisterResult property and the error code returned by the Write method are provided
+/// for debugging and diagnostics, but you'll usually ignore these in normal operation (most
+/// applications should continue to work even if tracing isn't working).
+/// </summary>
+public class PerfTracepoint : IDisposable
+{
+    private readonly TracepointHandle handle;
+
+    /// <summary>
+    /// As a performance optimization, avoid one level of indirection during calls to IsEnabled
+    /// by caching the enablement array. The contents of this array should be considered
+    /// read-only and MUST NOT be modified.
+    /// <br/>
+    /// When handle.IsInvalid, the array is shared for all invalid handles and is a normal allocation.
+    /// When !handle.IsInvalid, the array is unique for for each handle and is a pinned allocation.
+    /// </summary>
+    private readonly Int32[] enablementPointer;
+
+    /// <summary>
+    /// Given a user_events command string, attempts to register it.
+    /// <br/>
+    /// If registration succeeds, the new tracepoint will be valid and active:
+    /// IsEnabled is dynamic, RegisterResult == 0, Write is meaningful.
+    /// <br/>
+    /// If registration fails, the new tracepoint will be invalid and inactive:
+    /// IsEnabled == false, RegisterResult != 0, Write will always return EBADF.
+    /// </summary>
+    /// <param name="nameArgs">
+    /// <a href="https://docs.kernel.org/trace/user_events.html#registering">user_events command string</a>,
+    /// e.g. "MyEventName int arg1; u32 arg2". All chars should be 255 or less.
+    /// </param>
+    /// <param name="flags">
+    /// <a href="https://docs.kernel.org/trace/user_events.html#registering">user_reg flags</a>,
+    /// e.g. USER_EVENT_REG_PERSIST or USER_EVENT_REG_MULTI_FORMAT.
+    /// </param>
+    public PerfTracepoint(ReadOnlySpan<char> nameArgs, UInt16 flags = 0)
+    {
+        var h = TracepointHandle.Register(nameArgs, flags);
+        this.handle = h;
+        this.enablementPointer = h.DangerousGetEnablementPointer();
+    }
+
+    /// <summary>
+    /// Given a NUL-terminated Latin1-encoded user_events command string, attempts
+    /// to register it.
+    /// <br/>
+    /// If registration succeeds, the new tracepoint will be valid and active:
+    /// IsEnabled is dynamic, RegisterResult == 0, Write is meaningful.
+    /// <br/>
+    /// If registration fails, the new tracepoint will be invalid and inactive:
+    /// IsEnabled == false, RegisterResult != 0, Write will always return EBADF.
+    /// </summary>
+    /// <param name="nameArgs">
+    /// <a href="https://docs.kernel.org/trace/user_events.html#registering">user_events command string</a>,
+    /// Latin-1 encoded, NUL-terminated, e.g. "MyEventName int arg1; u32 arg2\0".
+    /// </param>
+    /// <param name="flags">
+    /// <a href="https://docs.kernel.org/trace/user_events.html#registering">user_reg flags</a>,
+    /// e.g. USER_EVENT_REG_PERSIST or USER_EVENT_REG_MULTI_FORMAT.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// nulTerminatedNameArgs does not contain any NUL termination (no 0 bytes).
+    /// </exception>
+    public PerfTracepoint(ReadOnlySpan<byte> nulTerminatedNameArgs, UInt16 flags = 0)
+    {
+        if (0 > nulTerminatedNameArgs.LastIndexOf((byte)0))
+        {
+            throw new ArgumentException(
+                nameof(nulTerminatedNameArgs) + " must contain a 0 byte",
+                nameof(nulTerminatedNameArgs));
+        }
+
+        var h = TracepointHandle.Register(nulTerminatedNameArgs, flags);
+        this.handle = h;
+        this.enablementPointer = h.DangerousGetEnablementPointer();
+    }
+
+    /// <summary>
+    /// If tracepoint registration succeeded, returns 0.
+    /// Otherwise, returns an errno indicating the error.
+    /// <br/>
+    /// This property is for diagnostic purposes and should usually be ignored for normal
+    /// operation -- most programs should continue to operate even if trace registration
+    /// fails.
+    /// </summary>
+    public int RegisterResult => this.handle.RegisterResult;
+
+    /// <summary>
+    /// Returns true if this tracepoint is registered and one or more tracepoint collecton sessions
+    /// are collecting this tracepoint.
+    /// <br/>
+    /// Returns false if this tracepoint is unregistered or if there are no tracepoint collection
+    /// sessions that are collecting this tracepoint. The tracepoint will be unregistered if
+    /// registration failed or if the tracepoint has been disposed.
+    /// <br/>
+    /// Note that this property is provided to support performance optimization, but use of this
+    /// property is optional -- it's ok to call Write even if IsEnabled returns false. If your
+    /// tracepoint is not being collected, the Write method will do nothing and will immediately
+    /// return EBADF. This property is provided so that you can efficiently skip preparing your data
+    /// and calling the Write method if your tracepoint is not being collected.
+    /// </summary>
+    public bool IsEnabled => this.enablementPointer[0] != 0;
+
+    /// <summary>
+    /// Unregisters the tracepoint. After calling Dispose(), IsEnabled will return false and
+    /// Write will do nothing and immediately return EBADF.
+    /// </summary>
+    public void Dispose()
+    {
+        this.Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with no data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write()
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        return this.handle.Write(stackalloc DataSegment[1]);
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with 1 chunk of data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write<T1>(
+        ReadOnlySpan<T1> v1)
+        where T1 : unmanaged
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        unsafe
+        {
+            fixed (void*
+                p1 = v1)
+            {
+                return this.handle.Write(stackalloc DataSegment[] {
+                    default,
+                    new DataSegment(p1, (uint)v1.Length * (uint)sizeof(T1)),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with 2 chunks of data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write<T1, T2>(
+        ReadOnlySpan<T1> v1,
+        ReadOnlySpan<T2> v2)
+        where T1 : unmanaged
+        where T2 : unmanaged
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        unsafe
+        {
+            fixed (void*
+                p1 = v1,
+                p2 = v2)
+            {
+                return this.handle.Write(stackalloc DataSegment[] {
+                    default,
+                    new DataSegment(p1, (uint)v1.Length * (uint)sizeof(T1)),
+                    new DataSegment(p2, (uint)v2.Length * (uint)sizeof(T2)),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with 3 chunks of data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write<T1, T2, T3>(
+        ReadOnlySpan<T1> v1,
+        ReadOnlySpan<T2> v2,
+        ReadOnlySpan<T3> v3)
+        where T1 : unmanaged
+        where T2 : unmanaged
+        where T3 : unmanaged
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        unsafe
+        {
+            fixed (void*
+                p1 = v1,
+                p2 = v2,
+                p3 = v3)
+            {
+                return this.handle.Write(stackalloc DataSegment[] {
+                    default,
+                    new DataSegment(p1, (uint)v1.Length * (uint)sizeof(T1)),
+                    new DataSegment(p2, (uint)v2.Length * (uint)sizeof(T2)),
+                    new DataSegment(p3, (uint)v3.Length * (uint)sizeof(T3)),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with 4 chunks of data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write<T1, T2, T3, T4>(
+        ReadOnlySpan<T1> v1,
+        ReadOnlySpan<T2> v2,
+        ReadOnlySpan<T3> v3,
+        ReadOnlySpan<T4> v4)
+        where T1 : unmanaged
+        where T2 : unmanaged
+        where T3 : unmanaged
+        where T4 : unmanaged
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        unsafe
+        {
+            fixed (void*
+                p1 = v1,
+                p2 = v2,
+                p3 = v3,
+                p4 = v4)
+            {
+                return this.handle.Write(stackalloc DataSegment[] {
+                    default,
+                    new DataSegment(p1, (uint)v1.Length * (uint)sizeof(T1)),
+                    new DataSegment(p2, (uint)v2.Length * (uint)sizeof(T2)),
+                    new DataSegment(p3, (uint)v3.Length * (uint)sizeof(T3)),
+                    new DataSegment(p4, (uint)v4.Length * (uint)sizeof(T4)),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with 5 chunks of data.
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    public int Write<T1, T2, T3, T4, T5>(
+        ReadOnlySpan<T1> v1,
+        ReadOnlySpan<T2> v2,
+        ReadOnlySpan<T3> v3,
+        ReadOnlySpan<T4> v4,
+        ReadOnlySpan<T5> v5)
+        where T1 : unmanaged
+        where T2 : unmanaged
+        where T3 : unmanaged
+        where T4 : unmanaged
+        where T5 : unmanaged
+    {
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        unsafe
+        {
+            fixed (void*
+                p1 = v1,
+                p2 = v2,
+                p3 = v3,
+                p4 = v4,
+                p5 = v5)
+            {
+                return this.handle.Write(stackalloc DataSegment[] {
+                    default,
+                    new DataSegment(p1, (uint)v1.Length * (uint)sizeof(T1)),
+                    new DataSegment(p2, (uint)v2.Length * (uint)sizeof(T2)),
+                    new DataSegment(p3, (uint)v3.Length * (uint)sizeof(T3)),
+                    new DataSegment(p4, (uint)v4.Length * (uint)sizeof(T4)),
+                    new DataSegment(p5, (uint)v5.Length * (uint)sizeof(T5)),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// If !IsEnabled, immediately returns EBADF.
+    /// Otherwise, writes an event with an arbitrary number of data chunks (uses Linux writev).
+    /// Precondition: segment[0].Length == 0 (the method uses segment[0] for headers).
+    /// </summary>
+    /// <returns>
+    /// 0 if event was written, errno otherwise.
+    /// Typically returns EBADF if no data collection sessions are listening for the tracepoint.
+    /// The return value is for debugging/diagnostic purposes and is usually ignored in normal operation
+    /// since most programs should continue to function even when tracing is not configured.
+    /// </returns>
+    internal int WriteSegments(Span<DataSegment> segments)
+    {
+        if (segments[0].Length != 0)
+        {
+            throw new ArgumentException("segments[0].Length must be 0", nameof(segments));
+        }
+
+        if (this.enablementPointer[0] == 0)
+        {
+            return TracepointHandle.DisabledEventError;
+        }
+
+        try
+        {
+            return this.handle.Write(segments);
+        }
+        finally
+        {
+            segments[0] = default;
+        }
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.handle.Dispose();
+        }
+    }
+}

--- a/Provider/Provider.csproj
+++ b/Provider/Provider.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Common.proj" />
+
+  <PropertyGroup>
+    <PackageId>Microsoft.LinuxTracepoints.Provider</PackageId>
+    <Title>Microsoft Linux Tracepoints Provider</Title>
+    <Description>Support for logging Linux user_events Tracepoints with EventHeader encoding.</Description>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <IncludeSymbols>True</IncludeSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Microsoft.LinuxTracepoints.Provider</AssemblyName>
+    <RootNamespace>Microsoft.LinuxTracepoints.Provider</RootNamespace>
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Types\Types.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Provider/README.md
+++ b/Provider/README.md
@@ -1,0 +1,11 @@
+﻿# Microsoft.LinuxTracepoints.Provider
+
+.NET library for logging Linux user_events Tracepoints with EventHeader encoding.
+
+Requires TargetFramework `net6.0` or later.
+
+## Changelog
+
+### 0.1.3 (TBD)
+
+- Initial release.

--- a/Provider/RawFileHandle.cs
+++ b/Provider/RawFileHandle.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.LinuxTracepoints.Provider;
+
+using System;
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// Wraps a raw Posix file descriptor returned from "open".
+/// Non-negative handle is a valid descriptor.
+/// Negative handle is a negative errno with the result of the "open" operation.
+/// </summary>
+internal sealed class RawFileHandle
+    : SafeHandle
+{
+    private const int UnknownErrno = int.MaxValue;
+
+    /// <summary>
+    /// Initializes a new handle that is invalid.
+    /// Do not use this constructor. To create a valid handle, call the static Open method.
+    /// </summary>
+    public RawFileHandle()
+        : base(new IntPtr(-UnknownErrno), true)
+    {
+        return;
+    }
+
+    /// <summary>
+    /// Returns true if handle is negative (stores a negative errno).
+    /// </summary>
+    public override bool IsInvalid => (nint)this.handle < 0;
+
+    /// <summary>
+    /// If open succeeded, returns 0. Otherwise returns the errno from open.
+    /// </summary>
+    public int OpenResult
+    {
+        get
+        {
+            var h = (nint)this.handle;
+            return h >= 0 ? 0 : -(int)h;
+        }
+    }
+
+    /// <summary>
+    /// Calls "open" with the given path name and with flags = O_WRONLY.
+    /// On success, returns a valid handle. On failure, returns an invalid handle
+    /// (check OpenResult for the errno).
+    /// </summary>
+    public static RawFileHandle OpenWRONLY(ReadOnlySpan<byte> nulTerminatedPathName)
+    {
+        var result = new RawFileHandle();
+
+        // Need a finally block to make sure the thread is not interrupted
+        // between the open and the handle assignment.
+        try
+        {
+            // Nothing.
+        }
+        finally
+        {
+            unsafe
+            {
+                fixed (byte* pathNamePtr = nulTerminatedPathName)
+                {
+                    const int O_WRONLY = 0x0001;
+                    result.handle = (nint)NativeMethods.open(pathNamePtr, O_WRONLY, 0);
+                }
+            }
+        }
+
+        if (0 > (nint)result.handle)
+        {
+            var errno = Marshal.GetLastWin32Error();
+            if (errno <= 0)
+            {
+                errno = UnknownErrno;
+            }
+
+            result.handle = new IntPtr(-errno);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Calls "writev" with the given data.
+    /// On success, returns the number of bytes written.
+    /// On error, returns -1 (check Marshal.GetLastWin32Error() for the errno).
+    /// </summary>
+    public nint WriteV(ReadOnlySpan<DataSegment> iovecs)
+    {
+        var needRelease = false;
+        try
+        {
+            this.DangerousAddRef(ref needRelease);
+            unsafe
+            {
+                fixed (DataSegment* iovecsPtr = iovecs)
+                {
+                    return NativeMethods.writev((Int32)(nint)this.handle, iovecsPtr, iovecs.Length);
+                }
+            }
+        }
+        finally
+        {
+            if (needRelease)
+            {
+                this.DangerousRelease();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Calls "ioctl" with the given request and data.
+    /// On error, returns -1 (check Marshal.GetLastWin32Error() for the errno).
+    /// </summary>
+    public int Ioctl<T>(uint request, ref T data)
+        where T : unmanaged
+    {
+        var needRelease = false;
+        try
+        {
+            this.DangerousAddRef(ref needRelease);
+            unsafe
+            {
+                fixed (void* dataPtr = &data)
+                {
+                    return NativeMethods.ioctl((Int32)(nint)this.handle, new UIntPtr(request), dataPtr);
+                }
+            }
+        }
+        finally
+        {
+            if (needRelease)
+            {
+                this.DangerousRelease();
+            }
+        }
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        var h = unchecked((Int32)(nint)this.handle);
+        return 0 <= NativeMethods.close(h);
+    }
+
+    private unsafe static class NativeMethods
+    {
+        [DllImport("libc", SetLastError = true)]
+        public static extern int close(Int32 fd);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int open(byte* pathname, Int32 flags, Int32 mode);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int ioctl(Int32 fd, UIntPtr request, void* data);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern IntPtr writev(Int32 fd, DataSegment* iovec, Int32 iovecCount);
+    }
+}

--- a/Provider/TracepointHandle.cs
+++ b/Provider/TracepointHandle.cs
@@ -1,0 +1,530 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.LinuxTracepoints.Provider;
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Debug = System.Diagnostics.Debug;
+using Interlocked = System.Threading.Interlocked;
+
+/// <summary>
+/// Low-level owner of a tracepoint registration.
+/// Handle is the tracepoint's write_index.
+/// Uses a pinned allocation for the tracepoint's is-enabled buffer.
+/// </summary>
+internal sealed class TracepointHandle : SafeHandle
+{
+    /// <summary>
+    /// The error to return from Write to a disabled event = EBADF = 9.
+    /// </summary>
+    public const int DisabledEventError = 9;
+
+    private const byte EnableSize = sizeof(UInt32);
+
+    private const int EBADF = 9;
+    private const int UnknownErrno = int.MaxValue;
+    private const int UnregisteredWriteIndex = -1;
+
+    private const int IOC_NRSHIFT = 0;
+    private const int IOC_TYPESHIFT = IOC_NRSHIFT + 8; // 8 = IOC_NRBITS
+    private const int IOC_SIZESHIFT = IOC_TYPESHIFT + 8; // 8 = IOC_TYPEBITS
+    private const int IOC_DIRSHIFT = IOC_SIZESHIFT + 14; // 14 = IOC_SIZEBITS
+    private const uint IOC_WRITE = 1;
+    private const uint IOC_READ = 2;
+    private const uint DIAG_IOC_MAGIC = '*';
+
+    private static RawFileHandle? userEventsDataStatic;
+    private static Int32[]? emptyEnabledPinned; // From normal heap.
+
+    /// <summary>
+    /// When this.IsInvalid, enabledPinned is a shared emptyEnabledPinned from the normal heap.
+    /// When !this.IsInvalid, enabledPinned is a unique allocation from the pinned object heap.
+    /// </summary>
+    private Int32[] enabledPinned;
+
+    /// <summary>
+    /// Initializes a new handle that is invalid.
+    /// </summary>
+#pragma warning disable CA1419 // Provide a parameterless constructor. (We don't need the runtime to create instances of TracepointHandle.)
+    private TracepointHandle()
+#pragma warning restore CA1419
+        : base((nint)UnregisteredWriteIndex, true)
+    {
+        var enabledPinned = emptyEnabledPinned ??
+            Utility.InterlockedInitSingleton(ref emptyEnabledPinned, new Int32[1]);
+        Debug.Assert(0 == enabledPinned[0]);
+        this.enabledPinned = enabledPinned;
+    }
+
+    /// <summary>
+    /// If registration succeeded, returns 0.
+    /// If registration failed, returns the errno from the failed open/ioctl.
+    /// </summary>
+    public int RegisterResult { get; private set; } = UnknownErrno;
+
+    /// <summary>
+    /// Returns true if this tracepoint is enabled, false otherwise.
+    /// Value may change at any time while the tracepoint is registered.
+    /// </summary>
+    public bool IsEnabled => 0 != this.enabledPinned[0];
+
+    /// <summary>
+    /// Returns true if registration was successful.
+    /// (Remains true even after handle is closed/disposed.)
+    /// </summary>
+    public override bool IsInvalid => (nint)UnregisteredWriteIndex == this.handle;
+
+    /// <summary>
+    /// Given an all-Latin1 user_events command string (no characters with value > 255),
+    /// attempts to register it. Returns a TracepointHandle with the result.
+    /// Syntax for nameArgs is given here:
+    /// https://docs.kernel.org/trace/user_events.html#command-format,
+    /// e.g. "MyEventName int arg1; u32 arg2".
+    /// <br/>
+    /// If registration succeeds, the returned handle will be valid and active:
+    /// IsInvalid == false, IsEnabled is dynamic, RegisterResult == 0,
+    /// Write is meaningful.
+    /// <br/>
+    /// If registration fails, the returned handle will be invalid and inactive:
+    /// IsInvalid == true, IsEnabled == false, RegisterResult != 0,
+    /// Write will always return EBADF.
+    /// </summary>
+    public static TracepointHandle Register(ReadOnlySpan<char> nameArgs, UInt16 flags = 0)
+    {
+        Span<byte> nulTerminatedNameArgs = stackalloc byte[nameArgs.Length + 1];
+        for (var i = 0; i < nameArgs.Length; i += 1)
+        {
+            nulTerminatedNameArgs[i] = unchecked((byte)nameArgs[i]);
+        }
+
+        nulTerminatedNameArgs[nameArgs.Length] = 0;
+        return Register(nulTerminatedNameArgs, flags);
+    }
+
+    /// <summary>
+    /// Given a NUL-terminated Latin1 user_events command string, attempts to register it.
+    /// Returns a TracepointHandle with the result.
+    /// Syntax for nameArgs is given here:
+    /// https://docs.kernel.org/trace/user_events.html#command-format,
+    /// e.g. "MyEventName int arg1; u32 arg2".
+    /// <br/>
+    /// If registration succeeds, the returned handle will be valid and active:
+    /// IsInvalid == false, IsEnabled is meaningful, RegisterResult == 0,
+    /// Write is meaningful.
+    /// <br/>
+    /// If registration fails, the returned handle will be invalid and inactive:
+    /// IsInvalid == true, IsEnabled == false, RegisterResult != 0,
+    /// Write will always return EBADF.
+    /// </summary>
+    public static TracepointHandle Register(ReadOnlySpan<byte> nulTerminatedNameArgs, UInt16 flags = 0)
+    {
+        Debug.Assert(0 <= nulTerminatedNameArgs.LastIndexOf((byte)0));
+
+        var tracepoint = new TracepointHandle();
+
+        var userEventsData = userEventsDataStatic ?? InitUserEventsDataStatic();
+        if (userEventsData.OpenResult != 0)
+        {
+            tracepoint.InitFailed(userEventsData.OpenResult);
+        }
+        else
+        {
+            var enabledPinned = GC.AllocateArray<Int32>(1, pinned: true);
+            Debug.Assert(0 == enabledPinned[0]);
+
+            int ioctlResult;
+            unsafe
+            {
+                fixed (Int32* enabledPtr = enabledPinned)
+                {
+                    fixed (byte* nameArgsPtr = nulTerminatedNameArgs)
+                    {
+                        var reg = new user_reg
+                        {
+                            size = user_reg.SizeOfStruct,
+                            enable_size = EnableSize,
+                            flags = flags,
+                            enable_addr = (nuint)enabledPtr,
+                            name_args = (nuint)nameArgsPtr,
+                        };
+
+                        // Need a finally block to make sure the thread is not interrupted
+                        // between the ioctl and the SetHandle.
+                        try
+                        {
+                            // Nothing.
+                        }
+                        finally
+                        {
+                            var DIAG_IOCSREG =
+                                ((IOC_WRITE | IOC_READ) << IOC_DIRSHIFT) |
+                                (DIAG_IOC_MAGIC << IOC_TYPESHIFT) |
+                                (0u << IOC_NRSHIFT) |
+                                ((uint)IntPtr.Size << IOC_SIZESHIFT);
+                            ioctlResult = userEventsData.Ioctl(DIAG_IOCSREG, ref reg);
+                            if (ioctlResult >= 0)
+                            {
+                                tracepoint.enabledPinned = enabledPinned;
+                                tracepoint.SetHandle((nint)reg.write_index);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (ioctlResult >= 0)
+            {
+                tracepoint.InitSucceeded();
+            }
+            else
+            {
+                var errno = Marshal.GetLastWin32Error();
+                if (errno <= 0)
+                {
+                    errno = UnknownErrno;
+                }
+
+                tracepoint.InitFailed(errno);
+            }
+        }
+
+        // All code paths should have called either InitSucceeded or InitFailed.
+        return tracepoint;
+    }
+
+    /// <summary>
+    /// Sends the data to the user_events_data file (does not check IsEnabled).
+    /// Uses data[0] for headers.
+    /// <br/>
+    /// Requires: data[0].Length == 0 (data[0] will be used for headers).
+    /// </summary>
+    public int Write(Span<DataSegment> data)
+    {
+        // Precondition: slot for write_index in data[0].
+        Debug.Assert(data[0].Length == 0);
+
+        var userEventsData = userEventsDataStatic;
+        Debug.Assert(userEventsData != null); // Otherwise there would be no TracepointHandle instance.
+        Debug.Assert(userEventsData.OpenResult == 0); // Otherwise Enabled would be false.
+
+        var writeIndex = (Int32)(nint)this.handle;
+        unsafe
+        {
+            data[0] = new DataSegment(&writeIndex, sizeof(Int32));
+        }
+
+        if (this.IsClosed)
+        {
+            return DisabledEventError;
+        }
+
+        // Ignore race condition: if we're disposed between checking IsClosed and calling WriteV,
+        // we will write the data using a write_index that doesn't belong to us. That's not great,
+        // but it's not fatal and probably not worth degrading performance to avoid it. The
+        // write_index is unlikely to be recycled during the race condition, and even if it is
+        // recycled, the worst consequence would be a garbage event in a trace. Could avoid with:
+        // try { AddRef; WriteV; } catch { return EBADF; } finally { Release; }.
+
+        var writevResult = userEventsData.WriteV(data);
+        return writevResult >= 0 ? 0 : Marshal.GetLastWin32Error();
+    }
+
+    /// <summary>
+    /// Returns an array of length 1 that contains the value that will be updated by the
+    /// kernel when the tracepoint is enabled or disabled. Caller MUST NOT modify the contents
+    /// of the array.
+    /// <br/>
+    /// When this.IsInvalid, the array is shared by all other invalid handles and is a normal allocation.
+    /// When !this.IsInvalid, there is a separate array for each handle and is a pinned allocation.
+    /// </summary>
+    public Int32[] DangerousGetEnablementPointer()
+    {
+        return this.enabledPinned;
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        var userEventsData = userEventsDataStatic;
+        Debug.Assert(userEventsData != null); // Otherwise there would be no TracepointHandle instance.
+
+        var enabledPinned = this.enabledPinned;
+        int ioctlResult;
+        unsafe
+        {
+            Debug.Assert(!ReferenceEquals(enabledPinned, emptyEnabledPinned));
+            fixed (Int32* enabledPtr = enabledPinned)
+            {
+                var unreg = new user_unreg
+                {
+                    size = user_unreg.SizeOfStruct,
+                    disable_addr = (nuint)enabledPtr,
+                };
+
+                var DIAG_IOCSUNREG =
+                    (IOC_WRITE << IOC_DIRSHIFT) |
+                    (DIAG_IOC_MAGIC << IOC_TYPESHIFT) |
+                    (2u << IOC_NRSHIFT) |
+                    ((uint)IntPtr.Size << IOC_SIZESHIFT);
+                ioctlResult = userEventsData.Ioctl(DIAG_IOCSUNREG, ref unreg);
+            }
+        }
+
+        enabledPinned[0] = 0; // Force IsEnabled = false.
+        return 0 <= ioctlResult;
+    }
+
+    /// <summary>
+    /// Locates and opens the user_events_data file.
+    /// First call to this will update userEventsDataStatic with the result.
+    /// </summary>
+    /// <returns>The new value of userEventsDataStatic (never null).</returns>
+    private static RawFileHandle InitUserEventsDataStatic()
+    {
+        RawFileHandle? resultHandle = null;
+        RawFileHandle? newHandle = null;
+        try
+        {
+            // "/sys/kernel/tracing/user_events_data\0"
+            ReadOnlySpan<byte> sysKernelTracingUserEventsData0 = stackalloc byte[] {
+                0x2F,0x73,0x79,0x73,0x2F,0x6B,0x65,0x72,0x6E,0x65,0x6C,0x2F,0x74,0x72,0x61,0x63,
+                0x69,0x6E,0x67,0x2F,0x75,0x73,0x65,0x72,0x5F,0x65,0x76,0x65,0x6E,0x74,0x73,0x5F,
+                0x64,0x61,0x74,0x61,0x00, };
+
+            newHandle = RawFileHandle.OpenWRONLY(sysKernelTracingUserEventsData0);
+            if (newHandle.OpenResult == 0)
+            {
+                // Success.
+            }
+            else if (!File.Exists("/proc/mounts"))
+            {
+                // Give up.
+            }
+            else
+            {
+                // "tracefs"
+                ReadOnlySpan<byte> tracefs = stackalloc byte[] {
+                    0x74,0x72,0x61,0x63,0x65,0x66,0x73, };
+
+                // "/user_events_data\0"
+                ReadOnlySpan<byte> tracefsSuffix0 = stackalloc byte[] {
+                    0x2F,0x75,0x73,0x65,0x72,0x5F,0x65,0x76,0x65,0x6E,0x74,0x73,0x5F,0x64,0x61,0x74,
+                    0x61,0x00, };
+
+                // "debugfs"
+                ReadOnlySpan<byte> debugfs = stackalloc byte[] {
+                    0x64,0x65,0x62,0x75,0x67,0x66,0x73, };
+
+                // "/tracing/user_events_data\0"
+                ReadOnlySpan<byte> debugfsSuffix0 = stackalloc byte[] {
+                    0x2F,0x74,0x72,0x61,0x63,0x69,0x6E,0x67,0x2F,0x75,0x73,0x65,0x72,0x5F,0x65,0x76,
+                    0x65,0x6E,0x74,0x73,0x5F,0x64,0x61,0x74,0x61,0x00, };
+
+                Span<byte> path = stackalloc byte[274]; // 256 + sizeof("/user_events_data\0")
+                FileStream? mounts = null;
+                try
+                {
+                    mounts = File.OpenRead("/proc/mounts");
+
+                    Span<byte> line = stackalloc byte[4096];
+                    bool eof = false;
+                    while (!eof)
+                    {
+                        // ~fgets
+                        int lineEnd;
+                        for (lineEnd = 0; lineEnd < line.Length; lineEnd += 1)
+                        {
+                            var b = mounts.ReadByte();
+                            if (b < 0)
+                            {
+                                eof = true;
+                                break;
+                            }
+                            else if (b == '\n')
+                            {
+                                break;
+                            }
+                            else
+                            {
+                                line[lineEnd] = (byte)b;
+                            }
+                        }
+
+                        // line is "device_name mount_point file_system other_stuff..."
+
+                        int linePos = 0;
+
+                        // device_name
+                        while (linePos < lineEnd && IsNonspaceByte(line[linePos]))
+                        {
+                            linePos += 1;
+                        }
+
+                        // whitespace
+                        while (linePos < lineEnd && IsSpaceByte(line[linePos]))
+                        {
+                            linePos += 1;
+                        }
+
+                        // mount_point
+                        var mountBegin = linePos;
+                        while (linePos < lineEnd && IsNonspaceByte(line[linePos]))
+                        {
+                            linePos += 1;
+                        }
+
+                        var mountEnd = linePos;
+
+                        // whitespace
+                        while (linePos < lineEnd && IsSpaceByte(line[linePos]))
+                        {
+                            linePos += 1;
+                        }
+
+                        // file_system
+                        var fsBegin = linePos;
+                        while (linePos < lineEnd && IsNonspaceByte(line[linePos]))
+                        {
+                            linePos += 1;
+                        }
+
+                        var fsEnd = linePos;
+
+                        if (linePos == lineEnd || !IsSpaceByte(line[linePos]))
+                        {
+                            // Ignore line if no whitespace after file_system.
+                            continue;
+                        }
+
+                        bool foundTraceFS;
+                        var fs = line.Slice(fsBegin, fsEnd - fsBegin);
+                        if (fs.SequenceEqual(tracefs))
+                        {
+                            // "tracefsMountPoint/user_events_data"
+                            foundTraceFS = true;
+                        }
+                        else if (path[0] == 0 && fs.SequenceEqual(debugfs))
+                        {
+                            // "debugfsMountPoint/tracing/user_events_data"
+                            foundTraceFS = false;
+                        }
+                        else
+                        {
+                            continue;
+                        }
+
+                        var pathSuffix0 = (foundTraceFS ? tracefsSuffix0 : debugfsSuffix0);
+
+                        var mountLen = mountEnd - mountBegin;
+                        var pathLen = mountLen + pathSuffix0.Length; // Includes NUL
+                        if (pathLen > path.Length)
+                        {
+                            continue;
+                        }
+
+                        // path = mountpoint + suffix
+                        line.Slice(mountBegin, mountLen).CopyTo(path);
+                        pathSuffix0.CopyTo(path.Slice(mountLen)); // Includes NUL
+
+                        if (foundTraceFS)
+                        {
+                            // Found a match, and it's tracefs, so stop looking.
+                            break;
+                        }
+                        else
+                        {
+                            // Found a match, but it's debugfs. We prefer tracefs, so keep looking.
+                        }
+                    }
+                }
+                catch (ArgumentException) { }
+                catch (IOException) { }
+                catch (NotSupportedException) { }
+                catch (UnauthorizedAccessException) { }
+                finally
+                {
+                    mounts?.Dispose();
+                }
+
+                if (path[0] != 0)
+                {
+                    newHandle.Dispose();
+                    newHandle = RawFileHandle.OpenWRONLY(path);
+                }
+            }
+
+            var oldHandle = Interlocked.CompareExchange(ref userEventsDataStatic, newHandle, null);
+            if (oldHandle != null)
+            {
+                resultHandle = oldHandle;
+            }
+            else
+            {
+                resultHandle = newHandle;
+            }
+        }
+        finally
+        {
+            if (newHandle != null && newHandle != resultHandle)
+            {
+                newHandle.Dispose();
+            }
+        }
+
+        return resultHandle;
+    }
+
+    private static bool IsSpaceByte(byte b)
+    {
+        return b == ' ' || b == '\t';
+    }
+
+    private static bool IsNonspaceByte(byte b)
+    {
+        return b != '\0' && !IsSpaceByte(b);
+    }
+
+    private void InitSucceeded()
+    {
+        this.RegisterResult = 0;
+        Debug.Assert(1 >= this.enabledPinned[0]);
+        Debug.Assert(!ReferenceEquals(this.enabledPinned, emptyEnabledPinned));
+        Debug.Assert(!this.IsClosed);
+        Debug.Assert(!this.IsInvalid);
+    }
+
+    private void InitFailed(int registerResult)
+    {
+        this.SetHandleAsInvalid();
+        this.RegisterResult = registerResult;
+        Debug.Assert(0 == this.enabledPinned[0]);
+        Debug.Assert(ReferenceEquals(this.enabledPinned, emptyEnabledPinned));
+        Debug.Assert(this.IsClosed);
+        Debug.Assert(this.IsInvalid);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private struct user_reg
+    {
+        public const int SizeOfStruct = 28;
+        public UInt32 size;
+        public byte enable_bit;
+        public byte enable_size;
+        public UInt16 flags;
+        public UInt64 enable_addr;
+        public UInt64 name_args;
+        public Int32 write_index;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private struct user_unreg
+    {
+        public const int SizeOfStruct = 16;
+        public UInt32 size;
+        public byte disable_bit;
+        public byte reserved;
+        public UInt16 reserved2;
+        public UInt64 disable_addr;
+    }
+}

--- a/Provider/Utility.cs
+++ b/Provider/Utility.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.LinuxTracepoints.Provider;
+
+using Interlocked = System.Threading.Interlocked;
+
+internal static class Utility
+{
+    /// <summary>
+    /// Atomically: old = location; if (old != null) { return old; } else { location = value; return value; }
+    /// </summary>
+    public static T InterlockedInitSingleton<T>(ref T? location, T value)
+        where T : class
+    {
+        return Interlocked.CompareExchange(ref location, value, null) ?? value;
+    }
+}

--- a/ProviderSample/Program.cs
+++ b/ProviderSample/Program.cs
@@ -1,0 +1,35 @@
+﻿namespace ProviderSample
+{
+    using Microsoft.LinuxTracepoints.Provider;
+    using System;
+
+    internal static class Program
+    {
+        static void Main(string[] args)
+        {
+            args = new string[] { "EmptyEvent", "Event1 int arg1" };
+
+            foreach (var arg in args)
+            {
+                Console.WriteLine();
+                Console.WriteLine("[{0}]:", arg);
+                using (var h = new PerfTracepoint(arg))
+                {
+                    Check(h);
+                    h.Dispose();
+                    Console.WriteLine("disposed:");
+                    Check(h);
+                }
+            }
+        }
+
+        static void Check(PerfTracepoint h)
+        {
+            int[] x = { 2 };
+            var span = new ReadOnlySpan<int>(x);
+            Console.WriteLine("  IsEnabled = {0}", h.IsEnabled);
+            Console.WriteLine("  RegisterResult = {0}", h.RegisterResult);
+            Console.WriteLine("  Write = {0}", h.Write(span));
+        }
+    }
+}

--- a/ProviderSample/ProviderSample.csproj
+++ b/ProviderSample/ProviderSample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Common.proj" />
+
+  <PropertyGroup>
+    <IsPackable>False</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Provider\Provider.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Prototype support for generating user_events tracepoints from .NET. Currently fairly basic - normal tracepoints only (no EventHeader support), does not help with packing your event (you declare whatever you want as your event format, and then you provide whatever data bytes you want as your event payload). But it works and seems reliable and fast.

Only exposed type so far is `PerfTracepoint`, which directly exposes registration and management of a tracepoint.

This requires .NET 5.0 or later due to the use of the Pinned Object Heap. Safe and efficient implementation requires the StatusWord to be allocated from pinned managed memory. Efficient long-term-pinned memory is not really available until .NET 5.0.

Low-level implementation:

- File handle object that owns a Posix file handle and provides support for writev and ioctl operations.
- DataSegment is for use with writev, and represents a Linux iovec (which basically means an EVENT_DATA_DESCRIPTOR in ETW terms).
- TracepointHandle object that owns a tracepoint registration and provides low-level support for:
  - Finding and opening the `user_events_status` file.
  - Registering tracepoints.
  - Checking whether tracepoints are enabled.
  - Writing tracepoint events.
  - Cleaning up.

That much is pretty stable and solid. The prototype part is what the public exposed interface should look like. For now, I'm just exposing raw (but memory-safe) access to a tracepoint via a PerfTracepoint class.

This class supports registering (caller directly provides the name-args string, which is not parsed or validated) in the constructor, supports an IsEnabled property (very efficient), and supports Write(...) with up to 5 parameters. Each parameter is a `ReadOnlySpan<T>`, so caller can provide just about any data they want as input.