### PR TITLE
Fix PerfItemType problems

### DIFF
--- a/Decode/EventHeaderItemInfo.cs
+++ b/Decode/EventHeaderItemInfo.cs
@@ -54,9 +54,9 @@ namespace Microsoft.LinuxTracepoints.Decode
         public PerfItemValue Value { get; }
 
         /// <summary>
-        /// Field type (same as Value.Type).
+        /// Field metadata (same as Value.Metadata).
         /// </summary>
-        public PerfItemType Type => this.Value.Type;
+        public PerfItemMetadata Metadata => this.Value.Metadata;
 
         /// <summary>
         /// UTF-8 encoded field name followed by 0 or more field attributes,
@@ -90,7 +90,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         {
             PerfConvert.StringAppendWithControlCharsJsonEscape(sb, this.NameBytes, Encoding.UTF8);
 
-            var fieldTag = this.Value.Type.FieldTag;
+            var fieldTag = this.Value.Metadata.FieldTag;
             if (fieldTag == 0)
             {
                 sb.Append(" = ");

--- a/Decode/PerfConvert.cs
+++ b/Decode/PerfConvert.cs
@@ -887,7 +887,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         }
 
         /// <summary>
-        /// Returns the number of chars required to convertOptions the provided byte array as a string
+        /// Returns the number of chars required to convert the provided byte array as a string
         /// of hexadecimal bytes (e.g. "0D 0A").
         /// If bytesLength is 0, returns 0. Otherwise returns (3 * bytesLength - 1).
         /// </summary>
@@ -1096,7 +1096,7 @@ namespace Microsoft.LinuxTracepoints.Decode
         /// Formats the provided 16-byte value as an IPv6 address.
         /// Requires appropriately-sized destination buffer, up to IPv6MaxChars.
         /// Returns the formatted string (the filled portion of destination).
-        /// Note: Allocates an IPAddress object to convertOptions the address.
+        /// Note: Allocates an IPAddress object to convert the address.
         /// </summary>
         public static Span<char> IPv6Format(Span<char> destination, ReadOnlySpan<byte> ipv6)
         {

--- a/Decode/PerfFieldFormat.cs
+++ b/Decode/PerfFieldFormat.cs
@@ -1026,12 +1026,14 @@ namespace Microsoft.LinuxTracepoints.Decode
 
         FixedSize:
 
+            var deducedEncoding = this.DeducedEncoding;
             return new PerfItemValue(
                 bytes,
-                new PerfItemType(
+                new PerfItemMetadata(
                     byteReader,
-                    this.DeducedEncoding,
+                    deducedEncoding,
                     this.DeducedFormat,
+                    0 == (deducedEncoding & EventHeaderFieldEncoding.ArrayFlagMask),
                     unchecked((byte)(1 << this.ElementSizeShift)),
                     arrayCount));
         }

--- a/Decode/README.md
+++ b/Decode/README.md
@@ -119,6 +119,24 @@ project. Feedback and contributions are welcome.
 
 ## Changelog
 
+### 0.1.4 (TBD)
+
+- Renamed `PerfItemType` to `PerfItemMetadata`. Renamed corresponding
+  methods and properties, `GetItemType()` ==> `GetItemMetadata()`,
+  `PerfItemValue.Type` ==> `PerfItemValue.Metadata`.
+- Fixed incorrect `PerfItemType.ElementCount` value for struct element.
+- Fixed handling of nul-terminated strings that are not terminated before
+  end of the event. Old behavior would treat field as invalid. New behavior
+  treats field as terminated at end of event.
+- Fixed some comments that had been corrupted by over-active
+  search-and-replace (i.e. Visual Studio rename incorrectly updated them).
+- Renamed item metadata's `ArrayFlags` property to `ArrayFlag` since only
+  one flag should be set at a time.
+- Added item metadata `IsScalar` and `IsElement` properties.
+- Removed item metadata `IsArrayOrElement` and `EncodingAndArrayFlags`
+  properties.
+- Added item value `AppendJsonTo()` method.
+
 ### 0.1.3 (2024-05-20)
 
 - Fix error when using `GetSampleEventInfo` or `GetNonSampleEventInfo` with

--- a/DecodePerfToJson/PerfToJson.cs
+++ b/DecodePerfToJson/PerfToJson.cs
@@ -238,14 +238,14 @@ namespace DecodePerfToJson
                                 switch (this.enumerator.State)
                                 {
                                     case EventHeaderEnumeratorState.Value:
-                                        if (!item.Value.Type.IsArrayOrElement)
+                                        if (!item.Value.Metadata.IsElement)
                                         {
                                             this.JsonWriter.WritePropertyName(MakeName(item, ref charBuf));
                                         }
                                         this.WriteValue(item.Value, ref charBuf);
                                         break;
                                     case EventHeaderEnumeratorState.StructBegin:
-                                        if (!item.Value.Type.IsArrayOrElement)
+                                        if (!item.Value.Metadata.IsElement)
                                         {
                                             this.JsonWriter.WritePropertyName(MakeName(item, ref charBuf));
                                         }
@@ -257,7 +257,7 @@ namespace DecodePerfToJson
                                     case EventHeaderEnumeratorState.ArrayBegin:
                                         this.JsonWriter.WritePropertyName(MakeName(item, ref charBuf));
                                         this.JsonWriter.WriteStartArray();
-                                        if (item.Value.Type.TypeSize != 0)
+                                        if (item.Value.Metadata.TypeSize != 0)
                                         {
                                             // Process the simple array directly without using the enumerator.
                                             WriteSimpleArrayValues(item.Value, ref charBuf);
@@ -370,7 +370,7 @@ namespace DecodePerfToJson
         {
             var fieldFormat = sampleEventInfo.Format.Fields[i];
             var fieldValue = fieldFormat.GetFieldValue(sampleEventInfo.RawDataSpan, sampleEventInfo.ByteReader);
-            if (!fieldValue.Type.IsArrayOrElement)
+            if (fieldValue.Metadata.IsScalar)
             {
                 this.JsonWriter.WritePropertyName(fieldFormat.Name);
                 this.WriteValue(fieldValue, ref charBuf);
@@ -494,7 +494,7 @@ namespace DecodePerfToJson
 
         private void WriteValue(in PerfItemValue item, ref Span<char> charBuf)
         {
-            switch (item.Type.Encoding)
+            switch (item.Metadata.Encoding)
             {
                 default:
                     throw new NotSupportedException("Unknown encoding.");
@@ -504,7 +504,7 @@ namespace DecodePerfToJson
                 case EventHeaderFieldEncoding.Struct:
                     throw new InvalidOperationException("Invalid encoding for FormatScalar.");
                 case EventHeaderFieldEncoding.Value8:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -528,7 +528,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value16:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -555,7 +555,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value32:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -591,7 +591,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value64:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -614,7 +614,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value128:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.HexBytes:
@@ -629,7 +629,7 @@ namespace DecodePerfToJson
                     }
                 case EventHeaderFieldEncoding.ZStringChar8:
                 case EventHeaderFieldEncoding.StringLength16Char8:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         case EventHeaderFieldFormat.HexBytes:
                             WriteHexBytesValue(item.Bytes, ref charBuf);
@@ -654,7 +654,7 @@ namespace DecodePerfToJson
                     }
                 case EventHeaderFieldEncoding.ZStringChar16:
                 case EventHeaderFieldEncoding.StringLength16Char16:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         case EventHeaderFieldFormat.HexBytes:
                             WriteHexBytesValue(item.Bytes, ref charBuf);
@@ -686,7 +686,7 @@ namespace DecodePerfToJson
                     }
                 case EventHeaderFieldEncoding.ZStringChar32:
                 case EventHeaderFieldEncoding.StringLength16Char32:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         case EventHeaderFieldFormat.HexBytes:
                             WriteHexBytesValue(item.Bytes, ref charBuf);
@@ -718,8 +718,8 @@ namespace DecodePerfToJson
         /// </summary>
         private void WriteSimpleArrayValues(in PerfItemValue item, ref Span<char> charBuf)
         {
-            var elementCount = item.Type.ElementCount;
-            switch (item.Type.Encoding)
+            var elementCount = item.Metadata.ElementCount;
+            switch (item.Metadata.Encoding)
             {
                 default:
                     throw new NotSupportedException("Unknown encoding.");
@@ -733,7 +733,7 @@ namespace DecodePerfToJson
                 case EventHeaderFieldEncoding.StringLength16Char32:
                     throw new InvalidOperationException("Invalid encoding for WriteSimpleArray.");
                 case EventHeaderFieldEncoding.Value8:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -776,7 +776,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value16:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -825,7 +825,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value32:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -891,7 +891,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value64:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.UnsignedInt:
@@ -932,7 +932,7 @@ namespace DecodePerfToJson
                             return;
                     }
                 case EventHeaderFieldEncoding.Value128:
-                    switch (item.Type.Format)
+                    switch (item.Metadata.Format)
                     {
                         default:
                         case EventHeaderFieldFormat.HexBytes:
@@ -1145,7 +1145,7 @@ namespace DecodePerfToJson
 
         private ReadOnlySpan<byte> MakeName(in EventHeaderItemInfo item, ref Span<char> charBuf)
         {
-            var tag = item.Value.Type.FieldTag;
+            var tag = item.Value.Metadata.FieldTag;
             var nameBytes = item.NameBytes;
             if (!this.JsonOptions.HasFlag(PerfConvertOptions.FieldTag) || tag == 0)
             {

--- a/DecodeSample/DataToWriter.cs
+++ b/DecodeSample/DataToWriter.cs
@@ -134,15 +134,7 @@ namespace DecodeSample
                             // formats. TraceFS fields are always scalars or arrays of fixed-size elements, so
                             // the following will work to get the data as a JSON value.
                             this.scratch.Clear();
-                            if (fieldValue.Type.IsArrayOrElement)
-                            {
-                                fieldValue.AppendJsonSimpleArrayTo(this.scratch);
-                            }
-                            else
-                            {
-                                fieldValue.AppendJsonScalarTo(this.scratch);
-                            }
-
+                            fieldValue.AppendJsonTo(this.scratch);
                             this.writer.WriteLine($"  {fieldFormat.Name} = {this.scratch}");
                         }
                     }

--- a/DecodeTest/DatDecode.cs
+++ b/DecodeTest/DatDecode.cs
@@ -73,7 +73,7 @@
                     {
                         var item = e.GetItemInfo();
                         _ = item.ToString(); // Exercise ToString.
-                        var itemType = item.Value.Type;
+                        var itemType = item.Value.Metadata;
                         this.writer.WritePropertyNameOnNewLine(MakeName(item.GetNameAsString(), itemType.FieldTag));
                         this.writer.WriteStartObject();
 
@@ -103,7 +103,7 @@
                             this.writer.WriteRaw("BadFixedSize", itemType.TypeSize.ToString(CultureInfo.InvariantCulture));
                         }
 
-                        if (itemType.ArrayFlags != 0)
+                        if (itemType.ArrayFlag != 0)
                         {
                             this.writer.WriteRaw("ElementCount", itemType.ElementCount.ToString(CultureInfo.InvariantCulture));
                         }
@@ -226,18 +226,18 @@
                 while (true)
                 {
                     var item = e.GetItemInfo();
-                    var itemType = item.Value.Type;
+                    var itemType = item.Value.Metadata;
                     switch (e.State)
                     {
                         case EventHeaderEnumeratorState.Value:
-                            if (!itemType.IsArrayOrElement)
+                            if (!itemType.IsElement)
                             {
                                 this.writer.WritePropertyNameOnNewLine(MakeName(item.GetNameAsString(), itemType.FieldTag));
                             }
                             item.Value.AppendJsonScalarTo(this.writer.WriteRawValueBuilder());
                             break;
                         case EventHeaderEnumeratorState.StructBegin:
-                            if (!itemType.IsArrayOrElement)
+                            if (!itemType.IsElement)
                             {
                                 this.writer.WritePropertyNameOnNewLine(MakeName(item.GetNameAsString(), itemType.FieldTag));
                             }
@@ -284,18 +284,18 @@
                 while (true)
                 {
                     var item = e.GetItemInfo();
-                    var itemType = item.Value.Type;
+                    var itemType = item.Value.Metadata;
                     switch (e.State)
                     {
                         case EventHeaderEnumeratorState.Value:
-                            if (!itemType.IsArrayOrElement)
+                            if (!itemType.IsElement)
                             {
                                 this.writer.WritePropertyNameOnNewLine(MakeName(item.GetNameAsString(), itemType.FieldTag));
                             }
                             this.writer.WriteStringValue(item.Value.ToString());
                             break;
                         case EventHeaderEnumeratorState.StructBegin:
-                            if (!itemType.IsArrayOrElement)
+                            if (!itemType.IsElement)
                             {
                                 this.writer.WritePropertyNameOnNewLine(MakeName(item.GetNameAsString(), itemType.FieldTag));
                             }

--- a/DecodeTest/TestPerfValue.cs
+++ b/DecodeTest/TestPerfValue.cs
@@ -299,10 +299,11 @@
             }
             return new PerfItemValue(
                 bytes,
-                new PerfItemType(
+                new PerfItemMetadata(
                     new PerfByteReader(fromBigEndian),
                     encoding,
                     format,
+                    true,
                     typeSize,
                     1));
         }
@@ -315,10 +316,11 @@
         {
             return new PerfItemValue(
                 bytes,
-                new PerfItemType(
+                new PerfItemMetadata(
                     new PerfByteReader(fromBigEndian),
                     encoding,
                     format,
+                    true,
                     0,
                     1));
         }

--- a/DecodeTest/TestTypes.cs
+++ b/DecodeTest/TestTypes.cs
@@ -28,7 +28,7 @@
                 var encoding = (EventHeaderFieldEncoding)value;
                 Assert.AreEqual(value, (byte)encoding);
                 Assert.AreEqual(value & 0x1F, (byte)encoding.BaseEncoding());
-                Assert.AreEqual(value & 0x60, (byte)encoding.ArrayFlags());
+                Assert.AreEqual(value & 0x60, (byte)encoding.ArrayFlag());
                 Assert.AreEqual((value & 0x20) != 0, encoding.IsCArray());
                 Assert.AreEqual((value & 0x40) != 0, encoding.IsVArray());
                 Assert.AreEqual((value & 0x60) != 0, encoding.IsArray());

--- a/Provider/PerfTracepoint.cs
+++ b/Provider/PerfTracepoint.cs
@@ -47,10 +47,10 @@ public enum PerfUserEventReg : UInt16
 /// Normal usage:
 /// <code>
 /// Tracepoint tp = new PerfTracepoint("MyEventName int MyField1; int MyField2");
-/// 
+///
 /// // To log an event where preparing the data is very simple:
 /// tp.Write(data...);
-/// 
+///
 /// // To log an event where preparing the data is expensive:
 /// if (tp.IsEnabled) // Skip preparing data and calling Write if the tracepoint is not enabled.
 /// {

--- a/Types/EventHeaderFieldEncoding.cs
+++ b/Types/EventHeaderFieldEncoding.cs
@@ -41,6 +41,11 @@ namespace Microsoft.LinuxTracepoints
         FlagMask = 0xE0,
 
         /// <summary>
+        /// Mask for the array flags: CArrayFlag, VArrayFlag.
+        /// </summary>
+        ArrayFlagMask = 0x60,
+
+        /// <summary>
         /// Constant-length array: 16-bit element count in metadata (must not be 0).
         /// </summary>
         CArrayFlag = 0x20,
@@ -142,14 +147,14 @@ namespace Microsoft.LinuxTracepoints
         /// <summary>
         /// Returns the array flags of the encoding (VArrayFlag or CArrayFlag, if set).
         /// </summary>
-        public static EventHeaderFieldEncoding ArrayFlags(this EventHeaderFieldEncoding encoding) =>
-            encoding & (EventHeaderFieldEncoding.VArrayFlag | EventHeaderFieldEncoding.CArrayFlag);
+        public static EventHeaderFieldEncoding ArrayFlag(this EventHeaderFieldEncoding encoding) =>
+            encoding & EventHeaderFieldEncoding.ArrayFlagMask;
 
         /// <summary>
         /// Returns true if any ArrayFlag is present (constant-length or variable-length array).
         /// </summary>
         public static bool IsArray(this EventHeaderFieldEncoding encoding) =>
-            0 != (encoding & (EventHeaderFieldEncoding.VArrayFlag | EventHeaderFieldEncoding.CArrayFlag));
+            0 != (encoding & EventHeaderFieldEncoding.ArrayFlagMask);
 
         /// <summary>
         /// Returns true if CArrayFlag is present (constant-length array).


### PR DESCRIPTION
While working on the Rust implementation of the decode library (using the .NET implementation as reference material), I found some issues with the .NET implementation.

- Some comments have been messed up by Visual Studio's "rename property" helper when it was accidentally run with "fix comments" enabled.
- Rust can't have properties named `type`, so I'm using `metadata` instead. While .NET allows properties named `Type`, I think `Metadata` is more accurate and descriptive, so update .NET to match.
- Only one Array flag can be set at a time on the item metadata, so rename `ArrayFlags` to `ArrayFlag`.
- It's really inconvenient and confusing to the user that the item info class doesn't track whether the item is an array or a scalar/element. It's bad in .NET, but even worse in Rust. We have a few bits free, so update the class to track this for the caller, and update the semantics of the class to match up with this new capability.

EventHeaderEnumerator.cs:

- Rename EventHeaderEnumerator.GetItemType() to GetItemMetadata().
- Fix the ElementCount property for struct element items returned by GetItemMetadata() or GetItemInfo() -- they should have had ElementCount = 1, but instead they had ElementCount = ArrayLength.
- "Fix" the handling of nul-terminated fields that don't have a nul-termination before the end of the event. Old behavior was to treat the field as invalid. New behavior is to consider them to end at the end of the event.

EventHeaderItemInfo.cs:

- Rename property `Type` to `Metadata`.

PerfItemType.cs:

- Future PR will rename this file to PerfItemMetadata.cs.
- Rewrote the struct comment.
- Renamed `PerfItemType` to `PerfItemMetadata`.
- Rewrote the constructor comment.
- Renamed property `EncodingAndArrayFlags` to `EncodingAndArrayFlagAndIsScalar` and made it private.
- Renamed constructor parameter `encodingAndArrayFlags` to `encodingAndArrayFlag` since only one array flag can be set at a time.
- Added constructor parameter `isScalar`. Value of this parameter gets stored in the ChainFlag bit of `EncodingAndArrayFlagAndIsScalar`.
- Renamed property `ArrayFlags` to `ArrayFlag`.
- Added properties `IsScalar` and `IsElement`.
- Removed property `IsArrayOrElement`.

PerfItemValue.cs:

- Rewrote the struct comment.
- Rewrote the constructor comment.
- Renamed property `Type` to `Metadata`.
- Add new method `AppendJsonTo()` which is possible because the metadata class now tracks `IsScalar`.