### PR TITLE
v0.2.0 - bump version, update README

### DIFF
--- a/Common.proj
+++ b/Common.proj
@@ -26,7 +26,7 @@
     <PackageTags>Tracepoints;Perf;Perf.data</PackageTags>
     <RepositoryUrl>https://github.com/microsoft/LinuxTracepoints-Net</RepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <VersionPrefix>0.1.3</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
 
   </PropertyGroup>

--- a/Decode/README.md
+++ b/Decode/README.md
@@ -119,7 +119,7 @@ project. Feedback and contributions are welcome.
 
 ## Changelog
 
-### 0.2.0 (TBD)
+### 0.2.0 (2024-06-19)
 
 - Renamed `PerfItemType` to `PerfItemMetadata`. Renamed corresponding
   methods and properties, `GetItemType()` ==> `GetItemMetadata()`,

--- a/DecodePerfToJson/Program.cs
+++ b/DecodePerfToJson/Program.cs
@@ -331,7 +331,7 @@ JSON options:
   FieldTag                    Fields with nonzero field tags are included in
                               field name e.g. ""Name;tag=0xNN"": value.
   FloatNonFiniteAsString      Non-finite float is a string instead of a null.
-  IntHexAsString                 Hex integer is string ""0xNNN"" instead of a
+  IntHexAsString              Hex integer is string ""0xNNN"" instead of a
                               number.
   BoolOutOfRangeAsString      Boolean other than 0..1 is string ""BOOL(N)""
                               instead of a number.

--- a/DecodePerfToJson/README.md
+++ b/DecodePerfToJson/README.md
@@ -3,6 +3,7 @@
 Tool for converting perf.data files to JSON text.
 
 ```
+
 Usage: DecodePerfToJson [options] input.perf.data
 
 Converts a perf.data file to JSON. Supports EventHeader-encoded events.
@@ -12,13 +13,13 @@ Options:
   -o, --output <file>  Write output to the specified file (default: stdout).
   -s, --sort <order>   Order events by file or time (default: time).
   -n, --nonsample      Include non-sample events in the output.
-  -i, --info <options> Comma-separated list of fields to include in "info".
+  -m, --meta <options> Comma-separated list of fields to include in "meta".
   -j, --json <options> Comma-separated list of JSON control options.
   -v, --validate       Validate the JSON output.
   -V, --novalidate     Do not validate the JSON output (default).
   -h, --help           Show this help message.
 
-Info options:
+Meta options:
 
   N               "n" field with the event identity before event.
   Time            "time" field with the event timestamp.
@@ -39,7 +40,7 @@ Info options:
   Flags           "flags" field with EventHeader provider flags.
   Common          Include "common" fields before the user fields.
 
-  Info fields will be omitted if not available or if the field has a default
+  Meta fields will be omitted if not available or if the field has a default
   value. For example, the "opcode" field will be omitted if it is 0, and the
   "tid" field will be omitted if it is the same as the "pid".
 
@@ -53,7 +54,7 @@ JSON options:
   FieldTag                    Fields with nonzero field tags are included in
                               field name e.g. "Name;tag=0xNN": value.
   FloatNonFiniteAsString      Non-finite float is a string instead of a null.
-  IntHexAsString              Hex integer is string "0xNNN" instead of a
+  IntHexAsString                 Hex integer is string "0xNNN" instead of a
                               number.
   BoolOutOfRangeAsString      Boolean other than 0..1 is string "BOOL(N)"
                               instead of a number.
@@ -82,11 +83,12 @@ project. Feedback and contributions are welcome.
 
 ## Changelog
 
-### 0.2.0 (TBD)
+### 0.2.0 (2024-06-19)
 
 - Add support for `BinaryLength16Char8` encoding.
 - Add support for extended formats for `StringLength16Char8` encoding.
 - Add support for `IPAddress` format.
+- Rename "info" suffix to "meta".
 
 ### 0.1.3 (2024-05-20)
 

--- a/DecodePerfToJson/README.md
+++ b/DecodePerfToJson/README.md
@@ -54,7 +54,7 @@ JSON options:
   FieldTag                    Fields with nonzero field tags are included in
                               field name e.g. "Name;tag=0xNN": value.
   FloatNonFiniteAsString      Non-finite float is a string instead of a null.
-  IntHexAsString                 Hex integer is string "0xNNN" instead of a
+  IntHexAsString              Hex integer is string "0xNNN" instead of a
                               number.
   BoolOutOfRangeAsString      Boolean other than 0..1 is string "BOOL(N)"
                               instead of a number.

--- a/DecodeTest/DatDecode.cs
+++ b/DecodeTest/DatDecode.cs
@@ -143,7 +143,7 @@
                         this.writer.WriteCommentValue($"Pos {pos}: Unexpected state {e.State}.");
                     }
 
-                    this.writer.WritePropertyNameOnNewLine("info");
+                    this.writer.WritePropertyNameOnNewLine("meta");
                     this.writer.WriteStartObject();
 
                     eventInfo.AppendJsonEventMetaTo(this.writer.WriteRawValueBuilder(), false, PerfMetaOptions.All, PerfConvertOptions.All);
@@ -171,7 +171,7 @@
                         this.writer.WriteCommentValue($"Pos {pos}: Unexpected state {e.State}.");
                     }
 
-                    this.writer.WritePropertyNameOnNewLine("info");
+                    this.writer.WritePropertyNameOnNewLine("meta");
                     this.writer.WriteStartObject();
 
                     eventInfo.AppendJsonEventMetaTo(this.writer.WriteRawValueBuilder(), false,

--- a/DecodeTest/expected/EventHeaderInterceptorLE64.dat.json
+++ b/DecodeTest/expected/EventHeaderInterceptorLE64.dat.json
@@ -5,11 +5,11 @@
     },
     "AppendJsonItemN": {
       "n": "Long_Provider_Name_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX0123456789:LongProviderEvent",
-      "info": { "provider": "Long_Provider_Name_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX0123456789", "event": "LongProviderEvent", "level": 5, "options": "Gasdf", "flags": "0x7" }
+      "meta": { "provider": "Long_Provider_Name_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX0123456789", "event": "LongProviderEvent", "level": 5, "options": "Gasdf", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
     },
@@ -26,11 +26,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderC:EventCG",
       "enabled": true,
-      "info": { "provider": "TestProviderC", "event": "EventCG", "level": 5, "options": "Gmsft", "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "EventCG", "level": 5, "options": "Gmsft", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "enabled":true,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "enabled": true
@@ -50,11 +50,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderCpp:EventCppG",
       "enabled": true,
-      "info": { "provider": "TestProviderCpp", "event": "EventCppG", "level": 5, "options": "Gmsft", "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "EventCppG", "level": 5, "options": "Gmsft", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "enabled":true,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "enabled": true
@@ -72,11 +72,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderC:CScalars1",
-      "info": { "provider": "TestProviderC", "event": "CScalars1", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "CScalars1", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
     },
@@ -91,11 +91,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderC:CScalars2",
-      "info": { "provider": "TestProviderC", "event": "CScalars2", "level": 1, "keyword": "0xF123456789ABCDEF", "opcode": 2, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "CScalars2", "level": 1, "keyword": "0xF123456789ABCDEF", "opcode": 2, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "keyword":17375808098319191535,"opcode":2 }
+      "meta": { "keyword":17375808098319191535,"opcode":2 }
     },
     "MoveNext": {
     },
@@ -114,11 +114,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderC:CScalars3",
       "Struct20;tag=0xBEEF": { "hi;tag=0x12": "hi", "ch10;tag=0x10": [ "H", "o", "w" ] },
-      "info": { "provider": "TestProviderC", "event": "CScalars3", "id": 1000, "version": 11, "level": 4, "keyword": "0x85", "opcode": 3, "tag": "0x1234", "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "CScalars3", "id": 1000, "version": 11, "level": 4, "keyword": "0x85", "opcode": 3, "tag": "0x1234", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "Struct20":{"hi":"hi","ch10":["H","o","w"]},
-      "info": { "id":1000,"version":11,"keyword":133,"opcode":3,"tag":4660 }
+      "meta": { "id":1000,"version":11,"keyword":133,"opcode":3,"tag":4660 }
     },
     "MoveNext": {
       "Struct20;tag=0xBEEF": {
@@ -142,11 +142,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderC:Transfer00",
-      "info": { "provider": "TestProviderC", "event": "Transfer00", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Transfer00", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
     },
@@ -161,11 +161,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderC:Transfer10",
-      "info": { "provider": "TestProviderC", "event": "Transfer10", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Transfer10", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "activity":"01020304-0506-0708-0102-030405060708" }
+      "meta": { "activity":"01020304-0506-0708-0102-030405060708" }
     },
     "MoveNext": {
     },
@@ -180,11 +180,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderC:Transfer11",
-      "info": { "provider": "TestProviderC", "event": "Transfer11", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "relatedActivity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Transfer11", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "relatedActivity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "activity":"01020304-0506-0708-0102-030405060708","relatedActivity":"01020304-0506-0708-0102-030405060708" }
+      "meta": { "activity":"01020304-0506-0708-0102-030405060708","relatedActivity":"01020304-0506-0708-0102-030405060708" }
     },
     "MoveNext": {
     },
@@ -203,11 +203,11 @@
       "n": "TestProviderC:i8",
       "i8": 100,
       "(-128)": -128,
-      "info": { "provider": "TestProviderC", "event": "i8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "i8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i8":100,"(-128)":-128,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i8": 100,
@@ -232,11 +232,11 @@
       "n": "TestProviderC:u8",
       "u8": 200,
       "(255)": 255,
-      "info": { "provider": "TestProviderC", "event": "u8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u8":200,"(255)":255,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u8": 200,
@@ -261,11 +261,11 @@
       "n": "TestProviderC:i16",
       "i16": 30000,
       "(-32767-1)": -32768,
-      "info": { "provider": "TestProviderC", "event": "i16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "i16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i16":30000,"(-32767-1)":-32768,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i16": 30000,
@@ -290,11 +290,11 @@
       "n": "TestProviderC:u16",
       "u16": 60000,
       "(65535)": 65535,
-      "info": { "provider": "TestProviderC", "event": "u16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16":60000,"(65535)":65535,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16": 60000,
@@ -319,11 +319,11 @@
       "n": "TestProviderC:i32",
       "i32": 2000000000,
       "(-2147483647-1)": -2147483648,
-      "info": { "provider": "TestProviderC", "event": "i32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "i32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":2000000000,"(-2147483647-1)":-2147483648,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": 2000000000,
@@ -348,11 +348,11 @@
       "n": "TestProviderC:u32",
       "u32": 4000000000,
       "(4294967295U)": 4294967295,
-      "info": { "provider": "TestProviderC", "event": "u32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32":4000000000,"(4294967295U)":4294967295,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32": 4000000000,
@@ -377,11 +377,11 @@
       "n": "TestProviderC:i64",
       "i64": 9000000000000000000,
       "(-9223372036854775807L-1)": -9223372036854775808,
-      "info": { "provider": "TestProviderC", "event": "i64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "i64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":9000000000000000000,"(-9223372036854775807L-1)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": 9000000000000000000,
@@ -406,11 +406,11 @@
       "n": "TestProviderC:u64",
       "u64": 18000000000000000000,
       "(18446744073709551615UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderC", "event": "u64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u64":18000000000000000000,"(18446744073709551615UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u64": 18000000000000000000,
@@ -435,11 +435,11 @@
       "n": "TestProviderC:iptr",
       "iptr": 1234,
       "(-9223372036854775807L-1)": -9223372036854775808,
-      "info": { "provider": "TestProviderC", "event": "iptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "iptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iptr":1234,"(-9223372036854775807L-1)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iptr": 1234,
@@ -464,11 +464,11 @@
       "n": "TestProviderC:uptr",
       "uptr": 4321,
       "(18446744073709551615UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderC", "event": "uptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "uptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uptr":4321,"(18446744073709551615UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uptr": 4321,
@@ -493,11 +493,11 @@
       "n": "TestProviderC:iL",
       "iL": 2000000000,
       "(-0x7fffffffffffffffL - 1L)": -9223372036854775808,
-      "info": { "provider": "TestProviderC", "event": "iL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "iL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iL":2000000000,"(-0x7fffffffffffffffL - 1L)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iL": 2000000000,
@@ -522,11 +522,11 @@
       "n": "TestProviderC:uL",
       "uL": 4000000000,
       "(0x7fffffffffffffffL * 2UL + 1UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderC", "event": "uL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "uL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uL":4000000000,"(0x7fffffffffffffffL * 2UL + 1UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uL": 4000000000,
@@ -551,11 +551,11 @@
       "n": "TestProviderC:hi8",
       "i8": "0x64",
       "(-128)": "0x80",
-      "info": { "provider": "TestProviderC", "event": "hi8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hi8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i8":"0x64","(-128)":"0x80",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i8": "0x64",
@@ -580,11 +580,11 @@
       "n": "TestProviderC:hu8",
       "u8": "0xC8",
       "(255)": "0xFF",
-      "info": { "provider": "TestProviderC", "event": "hu8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hu8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u8":"0xC8","(255)":"0xFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u8": "0xC8",
@@ -609,11 +609,11 @@
       "n": "TestProviderC:hi16",
       "i16": "0x7530",
       "(-32767-1)": "0x8000",
-      "info": { "provider": "TestProviderC", "event": "hi16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hi16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i16":"0x7530","(-32767-1)":"0x8000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i16": "0x7530",
@@ -638,11 +638,11 @@
       "n": "TestProviderC:hu16",
       "u16": "0xEA60",
       "(65535)": "0xFFFF",
-      "info": { "provider": "TestProviderC", "event": "hu16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hu16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16":"0xEA60","(65535)":"0xFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16": "0xEA60",
@@ -667,11 +667,11 @@
       "n": "TestProviderC:hi32",
       "i32": "0x77359400",
       "(-2147483647-1)": "0x80000000",
-      "info": { "provider": "TestProviderC", "event": "hi32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hi32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":"0x77359400","(-2147483647-1)":"0x80000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": "0x77359400",
@@ -696,11 +696,11 @@
       "n": "TestProviderC:hu32",
       "u32": "0xEE6B2800",
       "(4294967295U)": "0xFFFFFFFF",
-      "info": { "provider": "TestProviderC", "event": "hu32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hu32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32":"0xEE6B2800","(4294967295U)":"0xFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32": "0xEE6B2800",
@@ -725,11 +725,11 @@
       "n": "TestProviderC:hi64",
       "i64": "0x7CE66C50E2840000",
       "(-9223372036854775807L-1)": "0x8000000000000000",
-      "info": { "provider": "TestProviderC", "event": "hi64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hi64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":"0x7CE66C50E2840000","(-9223372036854775807L-1)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": "0x7CE66C50E2840000",
@@ -754,11 +754,11 @@
       "n": "TestProviderC:hu64",
       "u64": "0xF9CCD8A1C5080000",
       "(18446744073709551615UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderC", "event": "hu64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hu64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u64":"0xF9CCD8A1C5080000","(18446744073709551615UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u64": "0xF9CCD8A1C5080000",
@@ -783,11 +783,11 @@
       "n": "TestProviderC:hiptr",
       "iptr": "0x4D2",
       "(-9223372036854775807L-1)": "0x8000000000000000",
-      "info": { "provider": "TestProviderC", "event": "hiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iptr":"0x4D2","(-9223372036854775807L-1)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iptr": "0x4D2",
@@ -812,11 +812,11 @@
       "n": "TestProviderC:huptr",
       "uptr": "0x10E1",
       "(18446744073709551615UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderC", "event": "huptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "huptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uptr":"0x10E1","(18446744073709551615UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uptr": "0x10E1",
@@ -841,11 +841,11 @@
       "n": "TestProviderC:hiL",
       "iL": "0x77359400",
       "(-0x7fffffffffffffffL - 1L)": "0x8000000000000000",
-      "info": { "provider": "TestProviderC", "event": "hiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iL":"0x77359400","(-0x7fffffffffffffffL - 1L)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iL": "0x77359400",
@@ -870,11 +870,11 @@
       "n": "TestProviderC:huL",
       "uL": "0xEE6B2800",
       "(0x7fffffffffffffffL * 2UL + 1UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderC", "event": "huL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "huL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uL":"0xEE6B2800","(0x7fffffffffffffffL * 2UL + 1UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uL": "0xEE6B2800",
@@ -903,11 +903,11 @@
       "1/3": 0.333333343,
       "NaN": "NaN",
       "-Inf": "-Infinity",
-      "info": { "provider": "TestProviderC", "event": "f32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "f32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "f32":3.1400001,"1/3":0.333333343,"NaN":"NaN","-Inf":"-Infinity",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "f32": 3.1400001,
@@ -942,11 +942,11 @@
       "1/3": 0.33333333333333331,
       "NaN": "NaN",
       "-Inf": "-Infinity",
-      "info": { "provider": "TestProviderC", "event": "f64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "f64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "f64":6.2800000000000002,"1/3":0.33333333333333331,"NaN":"NaN","-Inf":"-Infinity",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "f64": 6.2800000000000002,
@@ -979,11 +979,11 @@
       "b0": false,
       "b1": true,
       "(255)": "BOOL(255)",
-      "info": { "provider": "TestProviderC", "event": "b8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "b8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0":false,"b1":true,"(255)":"BOOL(255)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "b0": false,
@@ -1013,11 +1013,11 @@
       "b0": false,
       "b1": true,
       "(-2147483647-1)": "BOOL(-2147483648)",
-      "info": { "provider": "TestProviderC", "event": "b32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "b32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0":false,"b1":true,"(-2147483647-1)":"BOOL(-2147483648)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "b0": false,
@@ -1045,11 +1045,11 @@
       "n": "TestProviderC:ch",
       "ch": "A",
       "FE": "þ",
-      "info": { "provider": "TestProviderC", "event": "ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ch":"A","FE":"þ",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ch": "A",
@@ -1074,11 +1074,11 @@
       "n": "TestProviderC:u16ch",
       "u16ch": "A",
       "FFFE": "￾",
-      "info": { "provider": "TestProviderC", "event": "u16ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u16ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16ch":"A","FFFE":"￾",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16ch": "A",
@@ -1107,11 +1107,11 @@
       "FFFE": "￾",
       "10FFFF": "􏿿",
       "FFFEFDFC": "�",
-      "info": { "provider": "TestProviderC", "event": "u32ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "u32ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32ch":"A","FFFE":"￾","10FFFF":"􏿿","FFFEFDFC":"�",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32ch": "A",
@@ -1146,11 +1146,11 @@
       "FFFE": "￾",
       "10FFFF": "􏿿",
       "0x7fffffff": "�",
-      "info": { "provider": "TestProviderC", "event": "wch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "wch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "wch":"B","FFFE":"￾","10FFFF":"􏿿","0x7fffffff":"�",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "wch": "B",
@@ -1181,11 +1181,11 @@
       "n": "TestProviderC:ptr",
       "pSamplePtr": "0xFFFFFFFFFFFFCFC7",
       "UINTPTR_MAX": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderC", "event": "ptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "pSamplePtr":"0xFFFFFFFFFFFFCFC7","UINTPTR_MAX":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "pSamplePtr": "0xFFFFFFFFFFFFCFC7",
@@ -1210,11 +1210,11 @@
       "n": "TestProviderC:pid",
       "i32": 2000000000,
       "(2147483647)": 2147483647,
-      "info": { "provider": "TestProviderC", "event": "pid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "pid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":2000000000,"(2147483647)":2147483647,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": 2000000000,
@@ -1239,11 +1239,11 @@
       "n": "TestProviderC:port",
       "port80": 80,
       "(65535)": 65535,
-      "info": { "provider": "TestProviderC", "event": "port", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "port", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "port80":80,"(65535)":65535,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "port80": 80,
@@ -1270,11 +1270,11 @@
       "(-2147483647-1)": "ERRNO(-2147483648)",
       "1": "EPERM(1)",
       "131": "ENOTRECOVERABLE(131)",
-      "info": { "provider": "TestProviderC", "event": "errno", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "errno", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "(-2147483647-1)":"ERRNO(-2147483648)","1":"EPERM(1)","131":"ENOTRECOVERABLE(131)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "(-2147483647-1)": "ERRNO(-2147483648)",
@@ -1306,11 +1306,11 @@
       "(-2147483647-1)": "1901-12-13T20:45:52Z",
       "(2147483647)": "2038-01-19T03:14:07Z",
       "0": "1970-01-01T00:00:00Z",
-      "info": { "provider": "TestProviderC", "event": "t32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "t32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":"2033-05-18T03:33:20Z","(-2147483647-1)":"1901-12-13T20:45:52Z","(2147483647)":"2038-01-19T03:14:07Z","0":"1970-01-01T00:00:00Z",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": "2033-05-18T03:33:20Z",
@@ -1353,11 +1353,11 @@
       "-11644473601": "1600-12-31T23:59:59Z",
       "910692730085": "TIME(910692730085)",
       "910692730086": "TIME(910692730086)",
-      "info": { "provider": "TestProviderC", "event": "t64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "t64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":"TIME(9000000000000000000)","(-9223372036854775807L-1)":"TIME(-9223372036854775808)","(9223372036854775807L)":"TIME(9223372036854775807)","0":"1970-01-01T00:00:00Z","-11644473600":"1601-01-01T00:00:00Z","-11644473601":"1600-12-31T23:59:59Z","910692730085":"TIME(910692730085)","910692730086":"TIME(910692730086)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": "TIME(9000000000000000000)",
@@ -1398,11 +1398,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderC:guid",
       "guid": "01020304-0506-0708-0102-030405060708",
-      "info": { "provider": "TestProviderC", "event": "guid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "guid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "guid":"01020304-0506-0708-0102-030405060708",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "guid": "01020304-0506-0708-0102-030405060708"
@@ -1424,11 +1424,11 @@
       "n": "TestProviderC:sz",
       "NULL": "",
       "ch10": "HowAreU8?",
-      "info": { "provider": "TestProviderC", "event": "sz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "sz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAreU8?",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1453,11 +1453,11 @@
       "n": "TestProviderC:sz8",
       "NULL": "",
       "ch10": "HowAreU8?",
-      "info": { "provider": "TestProviderC", "event": "sz8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "sz8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAreU8?",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1482,11 +1482,11 @@
       "n": "TestProviderC:wsz",
       "NULL": "",
       "wch10": "Goodbye!!",
-      "info": { "provider": "TestProviderC", "event": "wsz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "wsz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","wch10":"Goodbye!!",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1511,11 +1511,11 @@
       "n": "TestProviderC:sz16",
       "NULL": "",
       "u16ch10": "HowAreU16",
-      "info": { "provider": "TestProviderC", "event": "sz16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "sz16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u16ch10":"HowAreU16",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1540,11 +1540,11 @@
       "n": "TestProviderC:sz32",
       "NULL": "",
       "u32ch10": "HowAreU32",
-      "info": { "provider": "TestProviderC", "event": "sz32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "sz32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u32ch10":"HowAreU32",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1569,11 +1569,11 @@
       "n": "TestProviderC:csz",
       "NULL": "",
       "ch10": "HowAr",
-      "info": { "provider": "TestProviderC", "event": "csz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "csz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1598,11 +1598,11 @@
       "n": "TestProviderC:csz8",
       "NULL": "",
       "ch10": "HowAr",
-      "info": { "provider": "TestProviderC", "event": "csz8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "csz8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1627,11 +1627,11 @@
       "n": "TestProviderC:cwsz",
       "NULL": "",
       "wch10": "Goodb",
-      "info": { "provider": "TestProviderC", "event": "cwsz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "cwsz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","wch10":"Goodb",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1656,11 +1656,11 @@
       "n": "TestProviderC:csz16",
       "NULL": "",
       "u16ch10": "HowAr",
-      "info": { "provider": "TestProviderC", "event": "csz16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "csz16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u16ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1685,11 +1685,11 @@
       "n": "TestProviderC:csz32",
       "NULL": "",
       "u32ch10": "HowAr",
-      "info": { "provider": "TestProviderC", "event": "csz32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "csz32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u32ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1714,11 +1714,11 @@
       "n": "TestProviderC:bin",
       "NULL": "",
       "ch10": "48 6F 77 41 72",
-      "info": { "provider": "TestProviderC", "event": "bin", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "bin", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"48 6F 77 41 72",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -1743,11 +1743,11 @@
       "n": "TestProviderC:ipV4",
       "ipv4": "127.0.0.1",
       "(4294967295U)": "255.255.255.255",
-      "info": { "provider": "TestProviderC", "event": "ipV4", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ipV4", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ipv4":"127.0.0.1","(4294967295U)":"255.255.255.255",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ipv4": "127.0.0.1",
@@ -1772,11 +1772,11 @@
       "n": "TestProviderC:ipV6",
       "ipv6": "102:304:506:708:90a:b0c:d0e:f10",
       "fefe..fe00": "fefe:fefe:fefe:fefe:fefe:fefe:fefe:fe00",
-      "info": { "provider": "TestProviderC", "event": "ipV6", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ipV6", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ipv6":"102:304:506:708:90a:b0c:d0e:f10","fefe..fe00":"fefe:fefe:fefe:fefe:fefe:fefe:fefe:fe00",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ipv6": "102:304:506:708:90a:b0c:d0e:f10",
@@ -1801,11 +1801,11 @@
       "n": "TestProviderC:ai8",
       "a1": [ 100 ],
       "s": [ 100 ],
-      "info": { "provider": "TestProviderC", "event": "ai8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ai8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[100],"s":[100],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 100 ],
@@ -1830,11 +1830,11 @@
       "n": "TestProviderC:au8",
       "a1": [ 200 ],
       "s": [ 200 ],
-      "info": { "provider": "TestProviderC", "event": "au8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "au8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[200],"s":[200],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 200 ],
@@ -1859,11 +1859,11 @@
       "n": "TestProviderC:ai16",
       "a1": [ 30000 ],
       "s": [ 30000 ],
-      "info": { "provider": "TestProviderC", "event": "ai16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ai16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[30000],"s":[30000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 30000 ],
@@ -1888,11 +1888,11 @@
       "n": "TestProviderC:au16",
       "a1": [ 60000 ],
       "s": [ 60000 ],
-      "info": { "provider": "TestProviderC", "event": "au16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "au16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[60000],"s":[60000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 60000 ],
@@ -1917,11 +1917,11 @@
       "n": "TestProviderC:ai32",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderC", "event": "ai32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ai32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -1946,11 +1946,11 @@
       "n": "TestProviderC:au32",
       "a1": [ 4000000000 ],
       "s": [ 4000000000 ],
-      "info": { "provider": "TestProviderC", "event": "au32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "au32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4000000000 ],
@@ -1975,11 +1975,11 @@
       "n": "TestProviderC:ai64",
       "a1": [ 9000000000000000000 ],
       "s": [ 9000000000000000000 ],
-      "info": { "provider": "TestProviderC", "event": "ai64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ai64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 9000000000000000000 ],
@@ -2004,11 +2004,11 @@
       "n": "TestProviderC:au64",
       "a1": [ 18000000000000000000 ],
       "s": [ 18000000000000000000 ],
-      "info": { "provider": "TestProviderC", "event": "au64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "au64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18000000000000000000],"s":[18000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 18000000000000000000 ],
@@ -2033,11 +2033,11 @@
       "n": "TestProviderC:aiptr",
       "a1": [ 1234 ],
       "s": [ 1234 ],
-      "info": { "provider": "TestProviderC", "event": "aiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[1234],"s":[1234],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 1234 ],
@@ -2062,11 +2062,11 @@
       "n": "TestProviderC:auptr",
       "a1": [ 4321 ],
       "s": [ 4321 ],
-      "info": { "provider": "TestProviderC", "event": "auptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "auptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4321],"s":[4321],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4321 ],
@@ -2091,11 +2091,11 @@
       "n": "TestProviderC:aiL",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderC", "event": "aiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -2120,11 +2120,11 @@
       "n": "TestProviderC:auL",
       "a1": [ 4000000000 ],
       "s": [ 4000000000 ],
-      "info": { "provider": "TestProviderC", "event": "auL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "auL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4000000000 ],
@@ -2149,11 +2149,11 @@
       "n": "TestProviderC:hai8",
       "a1": [ "0x64" ],
       "s": [ "0x64" ],
-      "info": { "provider": "TestProviderC", "event": "hai8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hai8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[100],"s":[100],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x64" ],
@@ -2178,11 +2178,11 @@
       "n": "TestProviderC:hau8",
       "a1": [ "0xC8" ],
       "s": [ "0xC8" ],
-      "info": { "provider": "TestProviderC", "event": "hau8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hau8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[200],"s":[200],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xC8" ],
@@ -2207,11 +2207,11 @@
       "n": "TestProviderC:hai16",
       "a1": [ "0x7530" ],
       "s": [ "0x7530" ],
-      "info": { "provider": "TestProviderC", "event": "hai16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hai16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[30000],"s":[30000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x7530" ],
@@ -2236,11 +2236,11 @@
       "n": "TestProviderC:hau16",
       "a1": [ "0xEA60" ],
       "s": [ "0xEA60" ],
-      "info": { "provider": "TestProviderC", "event": "hau16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hau16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[60000],"s":[60000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEA60" ],
@@ -2265,11 +2265,11 @@
       "n": "TestProviderC:hai32",
       "a1": [ "0x77359400" ],
       "s": [ "0x77359400" ],
-      "info": { "provider": "TestProviderC", "event": "hai32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hai32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x77359400" ],
@@ -2294,11 +2294,11 @@
       "n": "TestProviderC:hau32",
       "a1": [ "0xEE6B2800" ],
       "s": [ "0xEE6B2800" ],
-      "info": { "provider": "TestProviderC", "event": "hau32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hau32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEE6B2800" ],
@@ -2323,11 +2323,11 @@
       "n": "TestProviderC:hai64",
       "a1": [ "0x7CE66C50E2840000" ],
       "s": [ "0x7CE66C50E2840000" ],
-      "info": { "provider": "TestProviderC", "event": "hai64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hai64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x7CE66C50E2840000" ],
@@ -2352,11 +2352,11 @@
       "n": "TestProviderC:hau64",
       "a1": [ "0xF9CCD8A1C5080000" ],
       "s": [ "0xF9CCD8A1C5080000" ],
-      "info": { "provider": "TestProviderC", "event": "hau64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hau64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18000000000000000000],"s":[18000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xF9CCD8A1C5080000" ],
@@ -2381,11 +2381,11 @@
       "n": "TestProviderC:haiptr",
       "a1": [ "0x4D2" ],
       "s": [ "0x4D2" ],
-      "info": { "provider": "TestProviderC", "event": "haiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "haiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[1234],"s":[1234],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x4D2" ],
@@ -2410,11 +2410,11 @@
       "n": "TestProviderC:hauptr",
       "a1": [ "0x10E1" ],
       "s": [ "0x10E1" ],
-      "info": { "provider": "TestProviderC", "event": "hauptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hauptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4321],"s":[4321],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x10E1" ],
@@ -2439,11 +2439,11 @@
       "n": "TestProviderC:haiL",
       "a1": [ "0x77359400" ],
       "s": [ "0x77359400" ],
-      "info": { "provider": "TestProviderC", "event": "haiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "haiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x77359400" ],
@@ -2468,11 +2468,11 @@
       "n": "TestProviderC:hauL",
       "a1": [ "0xEE6B2800" ],
       "s": [ "0xEE6B2800" ],
-      "info": { "provider": "TestProviderC", "event": "hauL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "hauL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEE6B2800" ],
@@ -2497,11 +2497,11 @@
       "n": "TestProviderC:af32",
       "a1": [ 3.1400001 ],
       "s": [ 3.1400001 ],
-      "info": { "provider": "TestProviderC", "event": "af32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "af32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[3.14],"s":[3.14],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 3.1400001 ],
@@ -2526,11 +2526,11 @@
       "n": "TestProviderC:af64",
       "a1": [ 6.2800000000000002 ],
       "s": [ 6.2800000000000002 ],
-      "info": { "provider": "TestProviderC", "event": "af64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "af64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[6.28],"s":[6.28],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 6.2800000000000002 ],
@@ -2555,11 +2555,11 @@
       "n": "TestProviderC:ab8",
       "a1": [ true ],
       "s": [ true ],
-      "info": { "provider": "TestProviderC", "event": "ab8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ab8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[true],"s":[true],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ true ],
@@ -2584,11 +2584,11 @@
       "n": "TestProviderC:ab32",
       "a1": [ true ],
       "s": [ true ],
-      "info": { "provider": "TestProviderC", "event": "ab32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ab32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[true],"s":[true],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ true ],
@@ -2613,11 +2613,11 @@
       "n": "TestProviderC:ach",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderC", "event": "ach", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ach", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -2642,11 +2642,11 @@
       "n": "TestProviderC:ach16",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderC", "event": "ach16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ach16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -2671,11 +2671,11 @@
       "n": "TestProviderC:ach32",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderC", "event": "ach32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ach32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -2700,11 +2700,11 @@
       "n": "TestProviderC:awch",
       "a4": [ "G", "o", "o", "d" ],
       "s5": [ "G", "o", "o", "d", "b" ],
-      "info": { "provider": "TestProviderC", "event": "awch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "awch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["G","o","o","d"],"s5":["G","o","o","d","b"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "G", "o", "o", "d" ],
@@ -2729,11 +2729,11 @@
       "n": "TestProviderC:aptr",
       "a1": [ "0xFFFFFFFFFFFFCFC7" ],
       "s": [ "0xFFFFFFFFFFFFCFC7" ],
-      "info": { "provider": "TestProviderC", "event": "aptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18446744073709539271],"s":[18446744073709539271],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xFFFFFFFFFFFFCFC7" ],
@@ -2758,11 +2758,11 @@
       "n": "TestProviderC:apid",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderC", "event": "apid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "apid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -2787,11 +2787,11 @@
       "n": "TestProviderC:aport",
       "a1": [ 24810 ],
       "s": [ 24810 ],
-      "info": { "provider": "TestProviderC", "event": "aport", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aport", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[24810],"s":[24810],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 24810 ],
@@ -2816,11 +2816,11 @@
       "n": "TestProviderC:aerrno",
       "a1": [ "ERRNO(2000000000)" ],
       "s": [ "ERRNO(2000000000)" ],
-      "info": { "provider": "TestProviderC", "event": "aerrno", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aerrno", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "ERRNO(2000000000)" ],
@@ -2845,11 +2845,11 @@
       "n": "TestProviderC:aft",
       "a1": [ "2033-05-18T03:33:20Z" ],
       "s": [ "2033-05-18T03:33:20Z" ],
-      "info": { "provider": "TestProviderC", "event": "aft", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "aft", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "2033-05-18T03:33:20Z" ],
@@ -2874,11 +2874,11 @@
       "n": "TestProviderC:auft",
       "a1": [ "TIME(9000000000000000000)" ],
       "s": [ "TIME(9000000000000000000)" ],
-      "info": { "provider": "TestProviderC", "event": "auft", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "auft", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "TIME(9000000000000000000)" ],
@@ -2903,11 +2903,11 @@
       "n": "TestProviderC:ag",
       "s0": [ ],
       "s1": [ "01020304-0506-0708-0102-030405060708" ],
-      "info": { "provider": "TestProviderC", "event": "ag", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ag", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "s0":[],"s1":["01020304-0506-0708-0102-030405060708"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "s0": [ ],
@@ -2932,11 +2932,11 @@
       "n": "TestProviderC:ahexbytes",
       "s0": [ ],
       "s1": [ "01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08" ],
-      "info": { "provider": "TestProviderC", "event": "ahexbytes", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "ahexbytes", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "s0":[],"s1":["01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "s0": [ ],
@@ -2979,11 +2979,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "Default", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Default", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "V8":200,"V16":60000,"V32":4000000000,"V64":18000000000000000000,"V128":"01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08","NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "V8": 200,
@@ -3053,11 +3053,11 @@
       "LChar8": "68 6A 6B 6C",
       "LChar16": "68 00 6A 00 6B 00 6C 00",
       "LChar32": "68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00",
-      "info": { "provider": "TestProviderC", "event": "HexBytes", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "HexBytes", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "V8":"01","V16":"01 02","V32":"01 02 03 04","V64":"01 02 03 04 05 06 07 08","V128":"01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08","NChar8":"68 6A 6B 6C","NChar16":"68 00 6A 00 6B 00 6C 00","NChar32":"68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00","LChar8":"68 6A 6B 6C","LChar16":"68 00 6A 00 6B 00 6C 00","LChar32":"68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "V8": "01",
@@ -3113,11 +3113,11 @@
       "true16": true,
       "u16": "BOOL(60000)",
       "i16": "BOOL(30000)",
-      "info": { "provider": "TestProviderC", "event": "Bool16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Bool16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "false16":false,"true16":true,"u16":"BOOL(60000)","i16":"BOOL(30000)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "false16": false,
@@ -3156,11 +3156,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringUtf", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringUtf", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3205,11 +3205,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringUtfBom-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringUtfBom-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3254,11 +3254,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringXml-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringXml-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3303,11 +3303,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringJson-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringJson-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3352,11 +3352,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringUtfBom-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringUtfBom-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3401,11 +3401,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringXml-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringXml-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3450,11 +3450,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringJson-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringJson-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3499,11 +3499,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringUtfBom-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringUtfBom-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3548,11 +3548,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringXml-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringXml-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3597,11 +3597,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderC", "event": "StringJson-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "StringJson-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -3646,11 +3646,11 @@
       "Struct1": { "NChar8": "hjkl" },
       "StructArray": [ { "Struct2": { "K": "A", "NChar16": "68 00 6A 00 6B 00 6C 00" } }, { "Struct2": { "K": "B", "NChar16": "FF FE 68 00 6A 00 6B 00 6C 00" } }, { "Struct2": { "K": "C", "NChar16": "FE FF 00 68 00 6A 00 6B 00 6C" } } ],
       "five": 5,
-      "info": { "provider": "TestProviderC", "event": "Packed", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Packed", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"Struct1":{"NChar8":"hjkl"},"StructArray":[{"Struct2":{"K":"A","NChar16":"68 00 6A 00 6B 00 6C 00"}},{"Struct2":{"K":"B","NChar16":"FF FE 68 00 6A 00 6B 00 6C 00"}},{"Struct2":{"K":"C","NChar16":"FE FF 00 68 00 6A 00 6B 00 6C"}}],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -3719,11 +3719,11 @@
       "Struct1": { "NChar8": "hjkl" },
       "StructArray": [ ],
       "five": 5,
-      "info": { "provider": "TestProviderC", "event": "Packed0", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "Packed0", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"Struct1":{"NChar8":"hjkl"},"StructArray":[],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -3759,11 +3759,11 @@
       "five": 5,
       "MyStrings3": [ "ABC", "", "XYZ" ],
       "five": 5,
-      "info": { "provider": "TestProviderC", "event": "PackedComplexArray", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "PackedComplexArray", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"MyStrings3":["ABC","","XYZ"],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -3789,11 +3789,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderC:EventCG",
       "enabled": true,
-      "info": { "provider": "TestProviderC", "event": "EventCG", "level": 5, "options": "Gmsft", "flags": "0x7" }
+      "meta": { "provider": "TestProviderC", "event": "EventCG", "level": 5, "options": "Gmsft", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "enabled":true,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "enabled": true
@@ -3813,11 +3813,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderCpp:EventCppG",
       "enabled": true,
-      "info": { "provider": "TestProviderCpp", "event": "EventCppG", "level": 5, "options": "Gmsft", "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "EventCppG", "level": 5, "options": "Gmsft", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "enabled":true,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "enabled": true
@@ -3835,11 +3835,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderCpp:CScalars1",
-      "info": { "provider": "TestProviderCpp", "event": "CScalars1", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "CScalars1", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
     },
@@ -3854,11 +3854,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderCpp:CScalars2",
-      "info": { "provider": "TestProviderCpp", "event": "CScalars2", "level": 1, "keyword": "0xF123456789ABCDEF", "opcode": 2, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "CScalars2", "level": 1, "keyword": "0xF123456789ABCDEF", "opcode": 2, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "keyword":17375808098319191535,"opcode":2 }
+      "meta": { "keyword":17375808098319191535,"opcode":2 }
     },
     "MoveNext": {
     },
@@ -3877,11 +3877,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderCpp:CScalars3",
       "Struct20;tag=0xBEEF": { "hi;tag=0x12": "hi", "ch10;tag=0x10": [ "H", "o", "w" ] },
-      "info": { "provider": "TestProviderCpp", "event": "CScalars3", "id": 1000, "version": 11, "level": 4, "keyword": "0x85", "opcode": 3, "tag": "0x1234", "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "CScalars3", "id": 1000, "version": 11, "level": 4, "keyword": "0x85", "opcode": 3, "tag": "0x1234", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "Struct20":{"hi":"hi","ch10":["H","o","w"]},
-      "info": { "id":1000,"version":11,"keyword":133,"opcode":3,"tag":4660 }
+      "meta": { "id":1000,"version":11,"keyword":133,"opcode":3,"tag":4660 }
     },
     "MoveNext": {
       "Struct20;tag=0xBEEF": {
@@ -3905,11 +3905,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderCpp:Transfer00",
-      "info": { "provider": "TestProviderCpp", "event": "Transfer00", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Transfer00", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
     },
@@ -3924,11 +3924,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderCpp:Transfer10",
-      "info": { "provider": "TestProviderCpp", "event": "Transfer10", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Transfer10", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "activity":"01020304-0506-0708-0102-030405060708" }
+      "meta": { "activity":"01020304-0506-0708-0102-030405060708" }
     },
     "MoveNext": {
     },
@@ -3943,11 +3943,11 @@
     },
     "AppendJsonItemN": {
       "n": "TestProviderCpp:Transfer11",
-      "info": { "provider": "TestProviderCpp", "event": "Transfer11", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "relatedActivity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Transfer11", "level": 5, "activity": "01020304-0506-0708-0102-030405060708", "relatedActivity": "01020304-0506-0708-0102-030405060708", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "": null,
-      "info": { "activity":"01020304-0506-0708-0102-030405060708","relatedActivity":"01020304-0506-0708-0102-030405060708" }
+      "meta": { "activity":"01020304-0506-0708-0102-030405060708","relatedActivity":"01020304-0506-0708-0102-030405060708" }
     },
     "MoveNext": {
     },
@@ -3966,11 +3966,11 @@
       "n": "TestProviderCpp:i8",
       "i8": 100,
       "(-128)": -128,
-      "info": { "provider": "TestProviderCpp", "event": "i8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "i8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i8":100,"(-128)":-128,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i8": 100,
@@ -3995,11 +3995,11 @@
       "n": "TestProviderCpp:u8",
       "u8": 200,
       "(255)": 255,
-      "info": { "provider": "TestProviderCpp", "event": "u8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u8":200,"(255)":255,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u8": 200,
@@ -4024,11 +4024,11 @@
       "n": "TestProviderCpp:i16",
       "i16": 30000,
       "(-32767-1)": -32768,
-      "info": { "provider": "TestProviderCpp", "event": "i16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "i16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i16":30000,"(-32767-1)":-32768,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i16": 30000,
@@ -4053,11 +4053,11 @@
       "n": "TestProviderCpp:u16",
       "u16": 60000,
       "(65535)": 65535,
-      "info": { "provider": "TestProviderCpp", "event": "u16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16":60000,"(65535)":65535,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16": 60000,
@@ -4082,11 +4082,11 @@
       "n": "TestProviderCpp:i32",
       "i32": 2000000000,
       "(-2147483647-1)": -2147483648,
-      "info": { "provider": "TestProviderCpp", "event": "i32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "i32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":2000000000,"(-2147483647-1)":-2147483648,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": 2000000000,
@@ -4111,11 +4111,11 @@
       "n": "TestProviderCpp:u32",
       "u32": 4000000000,
       "(4294967295U)": 4294967295,
-      "info": { "provider": "TestProviderCpp", "event": "u32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32":4000000000,"(4294967295U)":4294967295,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32": 4000000000,
@@ -4140,11 +4140,11 @@
       "n": "TestProviderCpp:i64",
       "i64": 9000000000000000000,
       "(-9223372036854775807L-1)": -9223372036854775808,
-      "info": { "provider": "TestProviderCpp", "event": "i64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "i64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":9000000000000000000,"(-9223372036854775807L-1)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": 9000000000000000000,
@@ -4169,11 +4169,11 @@
       "n": "TestProviderCpp:u64",
       "u64": 18000000000000000000,
       "(18446744073709551615UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderCpp", "event": "u64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u64":18000000000000000000,"(18446744073709551615UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u64": 18000000000000000000,
@@ -4198,11 +4198,11 @@
       "n": "TestProviderCpp:iptr",
       "iptr": 1234,
       "(-9223372036854775807L-1)": -9223372036854775808,
-      "info": { "provider": "TestProviderCpp", "event": "iptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "iptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iptr":1234,"(-9223372036854775807L-1)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iptr": 1234,
@@ -4227,11 +4227,11 @@
       "n": "TestProviderCpp:uptr",
       "uptr": 4321,
       "(18446744073709551615UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderCpp", "event": "uptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "uptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uptr":4321,"(18446744073709551615UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uptr": 4321,
@@ -4256,11 +4256,11 @@
       "n": "TestProviderCpp:iL",
       "iL": 2000000000,
       "(-0x7fffffffffffffffL - 1L)": -9223372036854775808,
-      "info": { "provider": "TestProviderCpp", "event": "iL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "iL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iL":2000000000,"(-0x7fffffffffffffffL - 1L)":-9223372036854775808,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iL": 2000000000,
@@ -4285,11 +4285,11 @@
       "n": "TestProviderCpp:uL",
       "uL": 4000000000,
       "(0x7fffffffffffffffL * 2UL + 1UL)": 18446744073709551615,
-      "info": { "provider": "TestProviderCpp", "event": "uL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "uL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uL":4000000000,"(0x7fffffffffffffffL * 2UL + 1UL)":18446744073709551615,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uL": 4000000000,
@@ -4314,11 +4314,11 @@
       "n": "TestProviderCpp:hi8",
       "i8": "0x64",
       "(-128)": "0x80",
-      "info": { "provider": "TestProviderCpp", "event": "hi8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hi8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i8":"0x64","(-128)":"0x80",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i8": "0x64",
@@ -4343,11 +4343,11 @@
       "n": "TestProviderCpp:hu8",
       "u8": "0xC8",
       "(255)": "0xFF",
-      "info": { "provider": "TestProviderCpp", "event": "hu8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hu8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u8":"0xC8","(255)":"0xFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u8": "0xC8",
@@ -4372,11 +4372,11 @@
       "n": "TestProviderCpp:hi16",
       "i16": "0x7530",
       "(-32767-1)": "0x8000",
-      "info": { "provider": "TestProviderCpp", "event": "hi16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hi16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i16":"0x7530","(-32767-1)":"0x8000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i16": "0x7530",
@@ -4401,11 +4401,11 @@
       "n": "TestProviderCpp:hu16",
       "u16": "0xEA60",
       "(65535)": "0xFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "hu16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hu16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16":"0xEA60","(65535)":"0xFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16": "0xEA60",
@@ -4430,11 +4430,11 @@
       "n": "TestProviderCpp:hi32",
       "i32": "0x77359400",
       "(-2147483647-1)": "0x80000000",
-      "info": { "provider": "TestProviderCpp", "event": "hi32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hi32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":"0x77359400","(-2147483647-1)":"0x80000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": "0x77359400",
@@ -4459,11 +4459,11 @@
       "n": "TestProviderCpp:hu32",
       "u32": "0xEE6B2800",
       "(4294967295U)": "0xFFFFFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "hu32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hu32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32":"0xEE6B2800","(4294967295U)":"0xFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32": "0xEE6B2800",
@@ -4488,11 +4488,11 @@
       "n": "TestProviderCpp:hi64",
       "i64": "0x7CE66C50E2840000",
       "(-9223372036854775807L-1)": "0x8000000000000000",
-      "info": { "provider": "TestProviderCpp", "event": "hi64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hi64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":"0x7CE66C50E2840000","(-9223372036854775807L-1)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": "0x7CE66C50E2840000",
@@ -4517,11 +4517,11 @@
       "n": "TestProviderCpp:hu64",
       "u64": "0xF9CCD8A1C5080000",
       "(18446744073709551615UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "hu64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hu64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u64":"0xF9CCD8A1C5080000","(18446744073709551615UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u64": "0xF9CCD8A1C5080000",
@@ -4546,11 +4546,11 @@
       "n": "TestProviderCpp:hiptr",
       "iptr": "0x4D2",
       "(-9223372036854775807L-1)": "0x8000000000000000",
-      "info": { "provider": "TestProviderCpp", "event": "hiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iptr":"0x4D2","(-9223372036854775807L-1)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iptr": "0x4D2",
@@ -4575,11 +4575,11 @@
       "n": "TestProviderCpp:huptr",
       "uptr": "0x10E1",
       "(18446744073709551615UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "huptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "huptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uptr":"0x10E1","(18446744073709551615UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uptr": "0x10E1",
@@ -4604,11 +4604,11 @@
       "n": "TestProviderCpp:hiL",
       "iL": "0x77359400",
       "(-0x7fffffffffffffffL - 1L)": "0x8000000000000000",
-      "info": { "provider": "TestProviderCpp", "event": "hiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "iL":"0x77359400","(-0x7fffffffffffffffL - 1L)":"0x8000000000000000",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "iL": "0x77359400",
@@ -4633,11 +4633,11 @@
       "n": "TestProviderCpp:huL",
       "uL": "0xEE6B2800",
       "(0x7fffffffffffffffL * 2UL + 1UL)": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "huL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "huL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "uL":"0xEE6B2800","(0x7fffffffffffffffL * 2UL + 1UL)":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "uL": "0xEE6B2800",
@@ -4666,11 +4666,11 @@
       "1/3": 0.333333343,
       "NaN": "NaN",
       "-Inf": "-Infinity",
-      "info": { "provider": "TestProviderCpp", "event": "f32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "f32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "f32":3.1400001,"1/3":0.333333343,"NaN":"NaN","-Inf":"-Infinity",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "f32": 3.1400001,
@@ -4705,11 +4705,11 @@
       "1/3": 0.33333333333333331,
       "NaN": "NaN",
       "-Inf": "-Infinity",
-      "info": { "provider": "TestProviderCpp", "event": "f64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "f64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "f64":6.2800000000000002,"1/3":0.33333333333333331,"NaN":"NaN","-Inf":"-Infinity",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "f64": 6.2800000000000002,
@@ -4742,11 +4742,11 @@
       "b0": false,
       "b1": true,
       "(255)": "BOOL(255)",
-      "info": { "provider": "TestProviderCpp", "event": "b8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "b8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0":false,"b1":true,"(255)":"BOOL(255)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "b0": false,
@@ -4776,11 +4776,11 @@
       "b0": false,
       "b1": true,
       "(-2147483647-1)": "BOOL(-2147483648)",
-      "info": { "provider": "TestProviderCpp", "event": "b32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "b32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0":false,"b1":true,"(-2147483647-1)":"BOOL(-2147483648)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "b0": false,
@@ -4808,11 +4808,11 @@
       "n": "TestProviderCpp:ch",
       "ch": "A",
       "FE": "þ",
-      "info": { "provider": "TestProviderCpp", "event": "ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ch":"A","FE":"þ",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ch": "A",
@@ -4837,11 +4837,11 @@
       "n": "TestProviderCpp:u16ch",
       "u16ch": "A",
       "FFFE": "￾",
-      "info": { "provider": "TestProviderCpp", "event": "u16ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u16ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u16ch":"A","FFFE":"￾",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u16ch": "A",
@@ -4870,11 +4870,11 @@
       "FFFE": "￾",
       "10FFFF": "􏿿",
       "FFFEFDFC": "�",
-      "info": { "provider": "TestProviderCpp", "event": "u32ch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "u32ch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "u32ch":"A","FFFE":"￾","10FFFF":"􏿿","FFFEFDFC":"�",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "u32ch": "A",
@@ -4909,11 +4909,11 @@
       "FFFE": "￾",
       "10FFFF": "􏿿",
       "0x7fffffff": "�",
-      "info": { "provider": "TestProviderCpp", "event": "wch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "wch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "wch":"B","FFFE":"￾","10FFFF":"􏿿","0x7fffffff":"�",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "wch": "B",
@@ -4944,11 +4944,11 @@
       "n": "TestProviderCpp:ptr",
       "pSamplePtr": "0xFFFFFFFFFFFFCFC7",
       "UINTPTR_MAX": "0xFFFFFFFFFFFFFFFF",
-      "info": { "provider": "TestProviderCpp", "event": "ptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "pSamplePtr":"0xFFFFFFFFFFFFCFC7","UINTPTR_MAX":"0xFFFFFFFFFFFFFFFF",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "pSamplePtr": "0xFFFFFFFFFFFFCFC7",
@@ -4973,11 +4973,11 @@
       "n": "TestProviderCpp:pid",
       "i32": 2000000000,
       "(2147483647)": 2147483647,
-      "info": { "provider": "TestProviderCpp", "event": "pid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "pid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":2000000000,"(2147483647)":2147483647,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": 2000000000,
@@ -5002,11 +5002,11 @@
       "n": "TestProviderCpp:port",
       "port80": 80,
       "(65535)": 65535,
-      "info": { "provider": "TestProviderCpp", "event": "port", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "port", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "port80":80,"(65535)":65535,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "port80": 80,
@@ -5033,11 +5033,11 @@
       "(-2147483647-1)": "ERRNO(-2147483648)",
       "1": "EPERM(1)",
       "131": "ENOTRECOVERABLE(131)",
-      "info": { "provider": "TestProviderCpp", "event": "errno", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "errno", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "(-2147483647-1)":"ERRNO(-2147483648)","1":"EPERM(1)","131":"ENOTRECOVERABLE(131)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "(-2147483647-1)": "ERRNO(-2147483648)",
@@ -5069,11 +5069,11 @@
       "(-2147483647-1)": "1901-12-13T20:45:52Z",
       "(2147483647)": "2038-01-19T03:14:07Z",
       "0": "1970-01-01T00:00:00Z",
-      "info": { "provider": "TestProviderCpp", "event": "t32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "t32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i32":"2033-05-18T03:33:20Z","(-2147483647-1)":"1901-12-13T20:45:52Z","(2147483647)":"2038-01-19T03:14:07Z","0":"1970-01-01T00:00:00Z",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i32": "2033-05-18T03:33:20Z",
@@ -5116,11 +5116,11 @@
       "-11644473601": "1600-12-31T23:59:59Z",
       "910692730085": "TIME(910692730085)",
       "910692730086": "TIME(910692730086)",
-      "info": { "provider": "TestProviderCpp", "event": "t64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "t64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "i64":"TIME(9000000000000000000)","(-9223372036854775807L-1)":"TIME(-9223372036854775808)","(9223372036854775807L)":"TIME(9223372036854775807)","0":"1970-01-01T00:00:00Z","-11644473600":"1601-01-01T00:00:00Z","-11644473601":"1600-12-31T23:59:59Z","910692730085":"TIME(910692730085)","910692730086":"TIME(910692730086)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "i64": "TIME(9000000000000000000)",
@@ -5161,11 +5161,11 @@
     "AppendJsonItemN": {
       "n": "TestProviderCpp:guid",
       "guid": "01020304-0506-0708-0102-030405060708",
-      "info": { "provider": "TestProviderCpp", "event": "guid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "guid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "guid":"01020304-0506-0708-0102-030405060708",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "guid": "01020304-0506-0708-0102-030405060708"
@@ -5187,11 +5187,11 @@
       "n": "TestProviderCpp:sz",
       "NULL": "",
       "ch10": "HowAreU8?",
-      "info": { "provider": "TestProviderCpp", "event": "sz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "sz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAreU8?",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5216,11 +5216,11 @@
       "n": "TestProviderCpp:sz8",
       "NULL": "",
       "ch10": "HowAreU8?",
-      "info": { "provider": "TestProviderCpp", "event": "sz8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "sz8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAreU8?",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5245,11 +5245,11 @@
       "n": "TestProviderCpp:wsz",
       "NULL": "",
       "wch10": "Goodbye!!",
-      "info": { "provider": "TestProviderCpp", "event": "wsz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "wsz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","wch10":"Goodbye!!",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5274,11 +5274,11 @@
       "n": "TestProviderCpp:sz16",
       "NULL": "",
       "u16ch10": "HowAreU16",
-      "info": { "provider": "TestProviderCpp", "event": "sz16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "sz16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u16ch10":"HowAreU16",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5303,11 +5303,11 @@
       "n": "TestProviderCpp:sz32",
       "NULL": "",
       "u32ch10": "HowAreU32",
-      "info": { "provider": "TestProviderCpp", "event": "sz32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "sz32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u32ch10":"HowAreU32",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5332,11 +5332,11 @@
       "n": "TestProviderCpp:csz",
       "NULL": "",
       "ch10": "HowAr",
-      "info": { "provider": "TestProviderCpp", "event": "csz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "csz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5361,11 +5361,11 @@
       "n": "TestProviderCpp:csz8",
       "NULL": "",
       "ch10": "HowAr",
-      "info": { "provider": "TestProviderCpp", "event": "csz8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "csz8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5390,11 +5390,11 @@
       "n": "TestProviderCpp:cwsz",
       "NULL": "",
       "wch10": "Goodb",
-      "info": { "provider": "TestProviderCpp", "event": "cwsz", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "cwsz", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","wch10":"Goodb",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5419,11 +5419,11 @@
       "n": "TestProviderCpp:csz16",
       "NULL": "",
       "u16ch10": "HowAr",
-      "info": { "provider": "TestProviderCpp", "event": "csz16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "csz16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u16ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5448,11 +5448,11 @@
       "n": "TestProviderCpp:csz32",
       "NULL": "",
       "u32ch10": "HowAr",
-      "info": { "provider": "TestProviderCpp", "event": "csz32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "csz32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","u32ch10":"HowAr",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5477,11 +5477,11 @@
       "n": "TestProviderCpp:bin",
       "NULL": "",
       "ch10": "48 6F 77 41 72",
-      "info": { "provider": "TestProviderCpp", "event": "bin", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "bin", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NULL":"","ch10":"48 6F 77 41 72",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NULL": "",
@@ -5506,11 +5506,11 @@
       "n": "TestProviderCpp:ipV4",
       "ipv4": "127.0.0.1",
       "(4294967295U)": "255.255.255.255",
-      "info": { "provider": "TestProviderCpp", "event": "ipV4", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ipV4", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ipv4":"127.0.0.1","(4294967295U)":"255.255.255.255",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ipv4": "127.0.0.1",
@@ -5535,11 +5535,11 @@
       "n": "TestProviderCpp:ipV6",
       "ipv6": "102:304:506:708:90a:b0c:d0e:f10",
       "fefe..fe00": "fefe:fefe:fefe:fefe:fefe:fefe:fefe:fe00",
-      "info": { "provider": "TestProviderCpp", "event": "ipV6", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ipV6", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "ipv6":"102:304:506:708:90a:b0c:d0e:f10","fefe..fe00":"fefe:fefe:fefe:fefe:fefe:fefe:fefe:fe00",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "ipv6": "102:304:506:708:90a:b0c:d0e:f10",
@@ -5564,11 +5564,11 @@
       "n": "TestProviderCpp:ai8",
       "a1": [ 100 ],
       "s": [ 100 ],
-      "info": { "provider": "TestProviderCpp", "event": "ai8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ai8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[100],"s":[100],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 100 ],
@@ -5593,11 +5593,11 @@
       "n": "TestProviderCpp:au8",
       "a1": [ 200 ],
       "s": [ 200 ],
-      "info": { "provider": "TestProviderCpp", "event": "au8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "au8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[200],"s":[200],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 200 ],
@@ -5622,11 +5622,11 @@
       "n": "TestProviderCpp:ai16",
       "a1": [ 30000 ],
       "s": [ 30000 ],
-      "info": { "provider": "TestProviderCpp", "event": "ai16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ai16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[30000],"s":[30000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 30000 ],
@@ -5651,11 +5651,11 @@
       "n": "TestProviderCpp:au16",
       "a1": [ 60000 ],
       "s": [ 60000 ],
-      "info": { "provider": "TestProviderCpp", "event": "au16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "au16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[60000],"s":[60000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 60000 ],
@@ -5680,11 +5680,11 @@
       "n": "TestProviderCpp:ai32",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "ai32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ai32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -5709,11 +5709,11 @@
       "n": "TestProviderCpp:au32",
       "a1": [ 4000000000 ],
       "s": [ 4000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "au32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "au32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4000000000 ],
@@ -5738,11 +5738,11 @@
       "n": "TestProviderCpp:ai64",
       "a1": [ 9000000000000000000 ],
       "s": [ 9000000000000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "ai64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ai64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 9000000000000000000 ],
@@ -5767,11 +5767,11 @@
       "n": "TestProviderCpp:au64",
       "a1": [ 18000000000000000000 ],
       "s": [ 18000000000000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "au64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "au64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18000000000000000000],"s":[18000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 18000000000000000000 ],
@@ -5796,11 +5796,11 @@
       "n": "TestProviderCpp:aiptr",
       "a1": [ 1234 ],
       "s": [ 1234 ],
-      "info": { "provider": "TestProviderCpp", "event": "aiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[1234],"s":[1234],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 1234 ],
@@ -5825,11 +5825,11 @@
       "n": "TestProviderCpp:auptr",
       "a1": [ 4321 ],
       "s": [ 4321 ],
-      "info": { "provider": "TestProviderCpp", "event": "auptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "auptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4321],"s":[4321],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4321 ],
@@ -5854,11 +5854,11 @@
       "n": "TestProviderCpp:aiL",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "aiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -5883,11 +5883,11 @@
       "n": "TestProviderCpp:auL",
       "a1": [ 4000000000 ],
       "s": [ 4000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "auL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "auL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 4000000000 ],
@@ -5912,11 +5912,11 @@
       "n": "TestProviderCpp:hai8",
       "a1": [ "0x64" ],
       "s": [ "0x64" ],
-      "info": { "provider": "TestProviderCpp", "event": "hai8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hai8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[100],"s":[100],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x64" ],
@@ -5941,11 +5941,11 @@
       "n": "TestProviderCpp:hau8",
       "a1": [ "0xC8" ],
       "s": [ "0xC8" ],
-      "info": { "provider": "TestProviderCpp", "event": "hau8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hau8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[200],"s":[200],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xC8" ],
@@ -5970,11 +5970,11 @@
       "n": "TestProviderCpp:hai16",
       "a1": [ "0x7530" ],
       "s": [ "0x7530" ],
-      "info": { "provider": "TestProviderCpp", "event": "hai16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hai16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[30000],"s":[30000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x7530" ],
@@ -5999,11 +5999,11 @@
       "n": "TestProviderCpp:hau16",
       "a1": [ "0xEA60" ],
       "s": [ "0xEA60" ],
-      "info": { "provider": "TestProviderCpp", "event": "hau16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hau16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[60000],"s":[60000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEA60" ],
@@ -6028,11 +6028,11 @@
       "n": "TestProviderCpp:hai32",
       "a1": [ "0x77359400" ],
       "s": [ "0x77359400" ],
-      "info": { "provider": "TestProviderCpp", "event": "hai32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hai32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x77359400" ],
@@ -6057,11 +6057,11 @@
       "n": "TestProviderCpp:hau32",
       "a1": [ "0xEE6B2800" ],
       "s": [ "0xEE6B2800" ],
-      "info": { "provider": "TestProviderCpp", "event": "hau32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hau32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEE6B2800" ],
@@ -6086,11 +6086,11 @@
       "n": "TestProviderCpp:hai64",
       "a1": [ "0x7CE66C50E2840000" ],
       "s": [ "0x7CE66C50E2840000" ],
-      "info": { "provider": "TestProviderCpp", "event": "hai64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hai64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x7CE66C50E2840000" ],
@@ -6115,11 +6115,11 @@
       "n": "TestProviderCpp:hau64",
       "a1": [ "0xF9CCD8A1C5080000" ],
       "s": [ "0xF9CCD8A1C5080000" ],
-      "info": { "provider": "TestProviderCpp", "event": "hau64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hau64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18000000000000000000],"s":[18000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xF9CCD8A1C5080000" ],
@@ -6144,11 +6144,11 @@
       "n": "TestProviderCpp:haiptr",
       "a1": [ "0x4D2" ],
       "s": [ "0x4D2" ],
-      "info": { "provider": "TestProviderCpp", "event": "haiptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "haiptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[1234],"s":[1234],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x4D2" ],
@@ -6173,11 +6173,11 @@
       "n": "TestProviderCpp:hauptr",
       "a1": [ "0x10E1" ],
       "s": [ "0x10E1" ],
-      "info": { "provider": "TestProviderCpp", "event": "hauptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hauptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4321],"s":[4321],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x10E1" ],
@@ -6202,11 +6202,11 @@
       "n": "TestProviderCpp:haiL",
       "a1": [ "0x77359400" ],
       "s": [ "0x77359400" ],
-      "info": { "provider": "TestProviderCpp", "event": "haiL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "haiL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0x77359400" ],
@@ -6231,11 +6231,11 @@
       "n": "TestProviderCpp:hauL",
       "a1": [ "0xEE6B2800" ],
       "s": [ "0xEE6B2800" ],
-      "info": { "provider": "TestProviderCpp", "event": "hauL", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "hauL", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[4000000000],"s":[4000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xEE6B2800" ],
@@ -6260,11 +6260,11 @@
       "n": "TestProviderCpp:af32",
       "a1": [ 3.1400001 ],
       "s": [ 3.1400001 ],
-      "info": { "provider": "TestProviderCpp", "event": "af32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "af32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[3.14],"s":[3.14],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 3.1400001 ],
@@ -6289,11 +6289,11 @@
       "n": "TestProviderCpp:af64",
       "a1": [ 6.2800000000000002 ],
       "s": [ 6.2800000000000002 ],
-      "info": { "provider": "TestProviderCpp", "event": "af64", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "af64", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[6.28],"s":[6.28],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 6.2800000000000002 ],
@@ -6318,11 +6318,11 @@
       "n": "TestProviderCpp:ab8",
       "a1": [ true ],
       "s": [ true ],
-      "info": { "provider": "TestProviderCpp", "event": "ab8", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ab8", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[true],"s":[true],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ true ],
@@ -6347,11 +6347,11 @@
       "n": "TestProviderCpp:ab32",
       "a1": [ true ],
       "s": [ true ],
-      "info": { "provider": "TestProviderCpp", "event": "ab32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ab32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[true],"s":[true],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ true ],
@@ -6376,11 +6376,11 @@
       "n": "TestProviderCpp:ach",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderCpp", "event": "ach", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ach", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -6405,11 +6405,11 @@
       "n": "TestProviderCpp:ach16",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderCpp", "event": "ach16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ach16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -6434,11 +6434,11 @@
       "n": "TestProviderCpp:ach32",
       "a4": [ "H", "o", "w", "A" ],
       "s5": [ "H", "o", "w", "A", "r" ],
-      "info": { "provider": "TestProviderCpp", "event": "ach32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ach32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["H","o","w","A"],"s5":["H","o","w","A","r"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "H", "o", "w", "A" ],
@@ -6463,11 +6463,11 @@
       "n": "TestProviderCpp:awch",
       "a4": [ "G", "o", "o", "d" ],
       "s5": [ "G", "o", "o", "d", "b" ],
-      "info": { "provider": "TestProviderCpp", "event": "awch", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "awch", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a4":["G","o","o","d"],"s5":["G","o","o","d","b"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a4": [ "G", "o", "o", "d" ],
@@ -6492,11 +6492,11 @@
       "n": "TestProviderCpp:aptr",
       "a1": [ "0xFFFFFFFFFFFFCFC7" ],
       "s": [ "0xFFFFFFFFFFFFCFC7" ],
-      "info": { "provider": "TestProviderCpp", "event": "aptr", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aptr", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[18446744073709539271],"s":[18446744073709539271],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "0xFFFFFFFFFFFFCFC7" ],
@@ -6521,11 +6521,11 @@
       "n": "TestProviderCpp:apid",
       "a1": [ 2000000000 ],
       "s": [ 2000000000 ],
-      "info": { "provider": "TestProviderCpp", "event": "apid", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "apid", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 2000000000 ],
@@ -6550,11 +6550,11 @@
       "n": "TestProviderCpp:aport",
       "a1": [ 24810 ],
       "s": [ 24810 ],
-      "info": { "provider": "TestProviderCpp", "event": "aport", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aport", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[24810],"s":[24810],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ 24810 ],
@@ -6579,11 +6579,11 @@
       "n": "TestProviderCpp:aerrno",
       "a1": [ "ERRNO(2000000000)" ],
       "s": [ "ERRNO(2000000000)" ],
-      "info": { "provider": "TestProviderCpp", "event": "aerrno", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aerrno", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "ERRNO(2000000000)" ],
@@ -6608,11 +6608,11 @@
       "n": "TestProviderCpp:aft",
       "a1": [ "2033-05-18T03:33:20Z" ],
       "s": [ "2033-05-18T03:33:20Z" ],
-      "info": { "provider": "TestProviderCpp", "event": "aft", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "aft", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[2000000000],"s":[2000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "2033-05-18T03:33:20Z" ],
@@ -6637,11 +6637,11 @@
       "n": "TestProviderCpp:auft",
       "a1": [ "TIME(9000000000000000000)" ],
       "s": [ "TIME(9000000000000000000)" ],
-      "info": { "provider": "TestProviderCpp", "event": "auft", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "auft", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "a1":[9000000000000000000],"s":[9000000000000000000],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "a1": [ "TIME(9000000000000000000)" ],
@@ -6666,11 +6666,11 @@
       "n": "TestProviderCpp:ag",
       "s0": [ ],
       "s1": [ "01020304-0506-0708-0102-030405060708" ],
-      "info": { "provider": "TestProviderCpp", "event": "ag", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ag", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "s0":[],"s1":["01020304-0506-0708-0102-030405060708"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "s0": [ ],
@@ -6695,11 +6695,11 @@
       "n": "TestProviderCpp:ahexbytes",
       "s0": [ ],
       "s1": [ "01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08" ],
-      "info": { "provider": "TestProviderCpp", "event": "ahexbytes", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "ahexbytes", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "s0":[],"s1":["01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08"],
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "s0": [ ],
@@ -6742,11 +6742,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "Default", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Default", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "V8":200,"V16":60000,"V32":4000000000,"V64":18000000000000000000,"V128":"01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08","NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "V8": 200,
@@ -6816,11 +6816,11 @@
       "LChar8": "68 6A 6B 6C",
       "LChar16": "68 00 6A 00 6B 00 6C 00",
       "LChar32": "68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00",
-      "info": { "provider": "TestProviderCpp", "event": "HexBytes", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "HexBytes", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "V8":"01","V16":"01 02","V32":"01 02 03 04","V64":"01 02 03 04 05 06 07 08","V128":"01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08","NChar8":"68 6A 6B 6C","NChar16":"68 00 6A 00 6B 00 6C 00","NChar32":"68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00","LChar8":"68 6A 6B 6C","LChar16":"68 00 6A 00 6B 00 6C 00","LChar32":"68 00 00 00 6A 00 00 00 6B 00 00 00 6C 00 00 00",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "V8": "01",
@@ -6876,11 +6876,11 @@
       "true16": true,
       "u16": "BOOL(60000)",
       "i16": "BOOL(30000)",
-      "info": { "provider": "TestProviderCpp", "event": "Bool16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Bool16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "false16":false,"true16":true,"u16":"BOOL(60000)","i16":"BOOL(30000)",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "false16": false,
@@ -6919,11 +6919,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringUtf", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringUtf", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -6968,11 +6968,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringUtfBom-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringUtfBom-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7017,11 +7017,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringXml-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringXml-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7066,11 +7066,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringJson-NoBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringJson-NoBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7115,11 +7115,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringUtfBom-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringUtfBom-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7164,11 +7164,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringXml-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringXml-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7213,11 +7213,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringJson-Bom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringJson-Bom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7262,11 +7262,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringUtfBom-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringUtfBom-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7311,11 +7311,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringXml-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringXml-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7360,11 +7360,11 @@
       "LChar8": "hjkl",
       "LChar16": "hjkl",
       "LChar32": "hjkl",
-      "info": { "provider": "TestProviderCpp", "event": "StringJson-XBom", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "StringJson-XBom", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "NChar8":"hjkl","NChar16":"hjkl","NChar32":"hjkl","LChar8":"hjkl","LChar16":"hjkl","LChar32":"hjkl",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "NChar8": "hjkl",
@@ -7409,11 +7409,11 @@
       "Struct1": { "NChar8": "hjkl" },
       "StructArray": [ { "Struct2": { "K": "A", "NChar16": "68 00 6A 00 6B 00 6C 00" } }, { "Struct2": { "K": "B", "NChar16": "FF FE 68 00 6A 00 6B 00 6C 00" } }, { "Struct2": { "K": "C", "NChar16": "FE FF 00 68 00 6A 00 6B 00 6C" } } ],
       "five": 5,
-      "info": { "provider": "TestProviderCpp", "event": "Packed", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Packed", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"Struct1":{"NChar8":"hjkl"},"StructArray":[{"Struct2":{"K":"A","NChar16":"68 00 6A 00 6B 00 6C 00"}},{"Struct2":{"K":"B","NChar16":"FF FE 68 00 6A 00 6B 00 6C 00"}},{"Struct2":{"K":"C","NChar16":"FE FF 00 68 00 6A 00 6B 00 6C"}}],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -7482,11 +7482,11 @@
       "Struct1": { "NChar8": "hjkl" },
       "StructArray": [ ],
       "five": 5,
-      "info": { "provider": "TestProviderCpp", "event": "Packed0", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Packed0", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"Struct1":{"NChar8":"hjkl"},"StructArray":[],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -7522,11 +7522,11 @@
       "five": 5,
       "MyStrings3": [ "ABC", "", "XYZ" ],
       "five": 5,
-      "info": { "provider": "TestProviderCpp", "event": "PackedComplexArray", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "PackedComplexArray", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "five":5,"MyStrings3":["ABC","","XYZ"],"five":5,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "five": 5,
@@ -7554,11 +7554,11 @@
       "n": "TestProviderCpp:Value:bool",
       "false;tag=0x1234": false,
       "true": true,
-      "info": { "provider": "TestProviderCpp", "event": "Value:bool", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:bool", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "false":false,"true":true,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "false;tag=0x1234": false,
@@ -7583,11 +7583,11 @@
       "n": "TestProviderCpp:Value:char",
       "0": "\u0000",
       "A": "A",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"\u0000","A":"A",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "\u0000",
@@ -7612,11 +7612,11 @@
       "n": "TestProviderCpp:Value:char16",
       "0": "\u0000",
       "A": "A",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char16", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char16", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"\u0000","A":"A",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "\u0000",
@@ -7641,11 +7641,11 @@
       "n": "TestProviderCpp:Value:char32",
       "0": "\u0000",
       "A": "A",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char32", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char32", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"\u0000","A":"A",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "\u0000",
@@ -7670,11 +7670,11 @@
       "n": "TestProviderCpp:Value:wchar",
       "0": "\u0000",
       "A": "A",
-      "info": { "provider": "TestProviderCpp", "event": "Value:wchar", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:wchar", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"\u0000","A":"A",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "\u0000",
@@ -7699,11 +7699,11 @@
       "n": "TestProviderCpp:Value:schar",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:schar", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:schar", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7728,11 +7728,11 @@
       "n": "TestProviderCpp:Value:uchar",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:uchar", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:uchar", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7757,11 +7757,11 @@
       "n": "TestProviderCpp:Value:sshort",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:sshort", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:sshort", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7786,11 +7786,11 @@
       "n": "TestProviderCpp:Value:ushort",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:ushort", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:ushort", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7815,11 +7815,11 @@
       "n": "TestProviderCpp:Value:sint",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:sint", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:sint", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7844,11 +7844,11 @@
       "n": "TestProviderCpp:Value:uint",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:uint", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:uint", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7873,11 +7873,11 @@
       "n": "TestProviderCpp:Value:slong",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:slong", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:slong", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7902,11 +7902,11 @@
       "n": "TestProviderCpp:Value:ulong",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:ulong", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:ulong", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7931,11 +7931,11 @@
       "n": "TestProviderCpp:Value:slonglong",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:slonglong", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:slonglong", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7960,11 +7960,11 @@
       "n": "TestProviderCpp:Value:ulonglong",
       "0": 0,
       "A": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:ulonglong", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:ulonglong", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"A":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -7989,11 +7989,11 @@
       "n": "TestProviderCpp:Value:float",
       "0": 0,
       "65": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:float", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:float", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"65":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -8018,11 +8018,11 @@
       "n": "TestProviderCpp:Value:double",
       "0": 0,
       "65": 65,
-      "info": { "provider": "TestProviderCpp", "event": "Value:double", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:double", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":0,"65":65,
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": 0,
@@ -8047,11 +8047,11 @@
       "n": "TestProviderCpp:Value:void*",
       "0": "0x0",
       "p": "0xFFFFFFFFFFFFCFC7",
-      "info": { "provider": "TestProviderCpp", "event": "Value:void*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:void*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"0x0","p":"0xFFFFFFFFFFFFCFC7",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "0x0",
@@ -8076,11 +8076,11 @@
       "n": "TestProviderCpp:Value:cvoid*",
       "0": "0x0",
       "p": "0xFFFFFFFFFFFFCFC7",
-      "info": { "provider": "TestProviderCpp", "event": "Value:cvoid*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:cvoid*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"0x0","p":"0xFFFFFFFFFFFFCFC7",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "0x0",
@@ -8105,11 +8105,11 @@
       "n": "TestProviderCpp:Value:char*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8134,11 +8134,11 @@
       "n": "TestProviderCpp:Value:cchar*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:cchar*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:cchar*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8163,11 +8163,11 @@
       "n": "TestProviderCpp:Value:char16_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char16_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char16_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8192,11 +8192,11 @@
       "n": "TestProviderCpp:Value:cchar16_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:cchar16_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:cchar16_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8221,11 +8221,11 @@
       "n": "TestProviderCpp:Value:char32_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:char32_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:char32_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8250,11 +8250,11 @@
       "n": "TestProviderCpp:Value:cchar32_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:cchar32_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:cchar32_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8279,11 +8279,11 @@
       "n": "TestProviderCpp:Value:wchar_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:wchar_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:wchar_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8308,11 +8308,11 @@
       "n": "TestProviderCpp:Value:cwchar_t*",
       "0": "",
       "hello": "hello",
-      "info": { "provider": "TestProviderCpp", "event": "Value:cwchar_t*", "level": 5, "flags": "0x7" }
+      "meta": { "provider": "TestProviderCpp", "event": "Value:cwchar_t*", "level": 5, "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "0":"","hello":"hello",
-      "info": {  }
+      "meta": {  }
     },
     "MoveNext": {
       "0": "",
@@ -8341,11 +8341,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -8380,11 +8380,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -8419,11 +8419,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -8458,11 +8458,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "F3 F2 F1 F0",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"01 00 00 00","s4one":"\u0001\u0000\u0000\u0000","b4big":"F3 F2 F1 F0","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "01 00 00 00",
@@ -8497,11 +8497,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -8536,11 +8536,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "default", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -8575,11 +8575,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -8614,11 +8614,11 @@
       "s1one": 1,
       "b1big": 240,
       "s1big": 240,
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":1,"s1one":1,"b1big":240,"s1big":240,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": 1,
@@ -8653,11 +8653,11 @@
       "s2one": 1,
       "b2big": 61681,
       "s2big": 61681,
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":1,"s2one":1,"b2big":61681,"s2big":61681,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": 1,
@@ -8692,11 +8692,11 @@
       "s4one": 1,
       "b4big": 4042388211,
       "s4big": 4042388211,
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":1,"s4one":1,"b4big":4042388211,"s4big":4042388211,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": 1,
@@ -8731,11 +8731,11 @@
       "s8one": 1,
       "b8big": 17361925168090707703,
       "s8big": 17361925168090707703,
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":1,"s8one":1,"b8big":17361925168090707703,"s8big":17361925168090707703,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": 1,
@@ -8770,11 +8770,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "unsigned_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -8809,11 +8809,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -8848,11 +8848,11 @@
       "s1one": 1,
       "b1big": -16,
       "s1big": -16,
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":1,"s1one":1,"b1big":-16,"s1big":-16,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": 1,
@@ -8887,11 +8887,11 @@
       "s2one": 1,
       "b2big": -3855,
       "s2big": -3855,
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":1,"s2one":1,"b2big":-3855,"s2big":-3855,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": 1,
@@ -8926,11 +8926,11 @@
       "s4one": 1,
       "b4big": -252579085,
       "s4big": -252579085,
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":1,"s4one":1,"b4big":-252579085,"s4big":-252579085,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": 1,
@@ -8965,11 +8965,11 @@
       "s8one": 1,
       "b8big": -1084818905618843913,
       "s8big": -1084818905618843913,
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":1,"s8one":1,"b8big":-1084818905618843913,"s8big":-1084818905618843913,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": 1,
@@ -9004,11 +9004,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "signed_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -9043,11 +9043,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -9082,11 +9082,11 @@
       "s1one": "0x1",
       "b1big": "0xF0",
       "s1big": "0xF0",
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"0x1","s1one":"0x1","b1big":"0xF0","s1big":"0xF0",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "0x1",
@@ -9121,11 +9121,11 @@
       "s2one": "0x1",
       "b2big": "0xF0F1",
       "s2big": "0xF0F1",
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"0x1","s2one":"0x1","b2big":"0xF0F1","s2big":"0xF0F1",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "0x1",
@@ -9160,11 +9160,11 @@
       "s4one": "0x1",
       "b4big": "0xF0F1F2F3",
       "s4big": "0xF0F1F2F3",
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"0x1","s4one":"0x1","b4big":"0xF0F1F2F3","s4big":"0xF0F1F2F3",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "0x1",
@@ -9199,11 +9199,11 @@
       "s8one": "0x1",
       "b8big": "0xF0F1F2F3F4F5F6F7",
       "s8big": "0xF0F1F2F3F4F5F6F7",
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"0x1","s8one":"0x1","b8big":"0xF0F1F2F3F4F5F6F7","s8big":"0xF0F1F2F3F4F5F6F7",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "0x1",
@@ -9238,11 +9238,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_int", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -9277,11 +9277,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -9316,11 +9316,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -9355,11 +9355,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -9394,11 +9394,11 @@
       "s4one": "EPERM(1)",
       "b4big": "ERRNO(-252579085)",
       "s4big": "ERRNO(-252579085)",
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"EPERM(1)","s4one":"EPERM(1)","b4big":"ERRNO(-252579085)","s4big":"ERRNO(-252579085)",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "EPERM(1)",
@@ -9433,11 +9433,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -9472,11 +9472,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "errno", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -9511,11 +9511,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -9550,11 +9550,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -9589,11 +9589,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -9628,11 +9628,11 @@
       "s4one": 1,
       "b4big": -252579085,
       "s4big": -252579085,
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":1,"s4one":1,"b4big":-252579085,"s4big":-252579085,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": 1,
@@ -9667,11 +9667,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -9706,11 +9706,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "pid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -9745,11 +9745,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -9784,11 +9784,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -9823,11 +9823,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -9862,11 +9862,11 @@
       "s4one": "1970-01-01T00:00:01Z",
       "b4big": "1961-12-30T15:08:35Z",
       "s4big": "1961-12-30T15:08:35Z",
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"1970-01-01T00:00:01Z","s4one":"1970-01-01T00:00:01Z","b4big":"1961-12-30T15:08:35Z","s4big":"1961-12-30T15:08:35Z",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "1970-01-01T00:00:01Z",
@@ -9901,11 +9901,11 @@
       "s8one": "1970-01-01T00:00:01Z",
       "b8big": "TIME(-1084818905618843913)",
       "s8big": "TIME(-1084818905618843913)",
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"1970-01-01T00:00:01Z","s8one":"1970-01-01T00:00:01Z","b8big":"TIME(-1084818905618843913)","s8big":"TIME(-1084818905618843913)",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "1970-01-01T00:00:01Z",
@@ -9940,11 +9940,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "time", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -9979,11 +9979,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -10018,11 +10018,11 @@
       "s1one": true,
       "b1big": "BOOL(240)",
       "s1big": "BOOL(240)",
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":true,"s1one":true,"b1big":"BOOL(240)","s1big":"BOOL(240)",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": true,
@@ -10057,11 +10057,11 @@
       "s2one": true,
       "b2big": "BOOL(61681)",
       "s2big": "BOOL(61681)",
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":true,"s2one":true,"b2big":"BOOL(61681)","s2big":"BOOL(61681)",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": true,
@@ -10096,11 +10096,11 @@
       "s4one": true,
       "b4big": "BOOL(-252579085)",
       "s4big": "BOOL(-252579085)",
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":true,"s4one":true,"b4big":"BOOL(-252579085)","s4big":"BOOL(-252579085)",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": true,
@@ -10135,11 +10135,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -10174,11 +10174,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "boolean", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -10213,11 +10213,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -10252,11 +10252,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -10291,11 +10291,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -10330,11 +10330,11 @@
       "s4one": 1.40129846e-45,
       "b4big": -5.9903676e+29,
       "s4big": -5.9903676e+29,
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":1.40129846e-45,"s4one":1.40129846e-45,"b4big":-5.9903676e+29,"s4big":-5.9903676e+29,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": 1.40129846e-45,
@@ -10369,11 +10369,11 @@
       "s8one": 4.9406564584124654e-324,
       "b8big": -1.1413996157316056e+236,
       "s8big": -1.1413996157316056e+236,
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":4.9406564584124654e-324,"s8one":4.9406564584124654e-324,"b8big":-1.1413996157316056e+236,"s8big":-1.1413996157316056e+236,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": 4.9406564584124654e-324,
@@ -10408,11 +10408,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "float", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -10447,11 +10447,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -10486,11 +10486,11 @@
       "s1one": "01",
       "b1big": "F0",
       "s1big": "F0",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"01","b1big":"F0","s1big":"F0",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -10525,11 +10525,11 @@
       "s2one": "01 00",
       "b2big": "F1 F0",
       "s2big": "F1 F0",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"01 00","b2big":"F1 F0","s2big":"F1 F0",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -10564,11 +10564,11 @@
       "s4one": "01 00 00 00",
       "b4big": "F3 F2 F1 F0",
       "s4big": "F3 F2 F1 F0",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"01 00 00 00","s4one":"01 00 00 00","b4big":"F3 F2 F1 F0","s4big":"F3 F2 F1 F0",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "01 00 00 00",
@@ -10603,11 +10603,11 @@
       "s8one": "01 00 00 00 00 00 00 00",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "F7 F6 F5 F4 F3 F2 F1 F0",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"01 00 00 00 00 00 00 00","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"F7 F6 F5 F4 F3 F2 F1 F0",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -10642,11 +10642,11 @@
       "s16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
-      "info": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "hex_bytes", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -10681,11 +10681,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -10720,11 +10720,11 @@
       "s1one": "\u0001",
       "b1big": "ð",
       "s1big": "ð",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"\u0001","s1one":"\u0001","b1big":"ð","s1big":"ð",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "\u0001",
@@ -10759,11 +10759,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "ñð",
       "s2big": "ñð",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"\u0001\u0000","s2one":"\u0001\u0000","b2big":"ñð","s2big":"ñð",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "\u0001\u0000",
@@ -10798,11 +10798,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "óòñð",
       "s4big": "óòñð",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"\u0001\u0000\u0000\u0000","s4one":"\u0001\u0000\u0000\u0000","b4big":"óòñð","s4big":"óòñð",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "\u0001\u0000\u0000\u0000",
@@ -10837,11 +10837,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "÷öõôóòñð",
       "s8big": "÷öõôóòñð",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"÷öõôóòñð","s8big":"÷öõôóòñð",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
@@ -10876,11 +10876,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "ðñòóôõö÷øùúûüýþÿ",
       "s16big": "ðñòóôõö÷øùúûüýþÿ",
-      "info": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string8", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"ðñòóôõö÷øùúûüýþÿ","s16big":"ðñòóôõö÷øùúûüýþÿ",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
@@ -10915,11 +10915,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -10954,11 +10954,11 @@
       "s1one": "\u0001",
       "b1big": "�",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"\u0001","s1one":"\u0001","b1big":"�","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "\u0001",
@@ -10993,11 +10993,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "��",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"\u0001\u0000","s2one":"\u0001\u0000","b2big":"��","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "\u0001\u0000",
@@ -11032,11 +11032,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "����",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"\u0001\u0000\u0000\u0000","s4one":"\u0001\u0000\u0000\u0000","b4big":"����","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "\u0001\u0000\u0000\u0000",
@@ -11071,11 +11071,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "��������",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"��������","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
@@ -11110,11 +11110,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "����������������",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"����������������","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
@@ -11149,11 +11149,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -11188,11 +11188,11 @@
       "s1one": "\u0001",
       "b1big": "�",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"\u0001","s1one":"\u0001","b1big":"�","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "\u0001",
@@ -11227,11 +11227,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "��",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"\u0001\u0000","s2one":"\u0001\u0000","b2big":"��","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "\u0001\u0000",
@@ -11266,11 +11266,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "����",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"\u0001\u0000\u0000\u0000","s4one":"\u0001\u0000\u0000\u0000","b4big":"����","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "\u0001\u0000\u0000\u0000",
@@ -11305,11 +11305,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "��������",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"��������","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
@@ -11344,11 +11344,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "����������������",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_utf_bom", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"����������������","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
@@ -11383,11 +11383,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -11422,11 +11422,11 @@
       "s1one": "\u0001",
       "b1big": "�",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"\u0001","s1one":"\u0001","b1big":"�","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "\u0001",
@@ -11461,11 +11461,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "��",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"\u0001\u0000","s2one":"\u0001\u0000","b2big":"��","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "\u0001\u0000",
@@ -11500,11 +11500,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "����",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"\u0001\u0000\u0000\u0000","s4one":"\u0001\u0000\u0000\u0000","b4big":"����","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "\u0001\u0000\u0000\u0000",
@@ -11539,11 +11539,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "��������",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"��������","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
@@ -11578,11 +11578,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "����������������",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_xml", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"����������������","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
@@ -11617,11 +11617,11 @@
       "s0one": "",
       "b0big": "",
       "s0big": "",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":"","s0one":"","b0big":"","s0big":"",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": "",
@@ -11656,11 +11656,11 @@
       "s1one": "\u0001",
       "b1big": "�",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"\u0001","s1one":"\u0001","b1big":"�","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "\u0001",
@@ -11695,11 +11695,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "��",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"\u0001\u0000","s2one":"\u0001\u0000","b2big":"��","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "\u0001\u0000",
@@ -11734,11 +11734,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "����",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"\u0001\u0000\u0000\u0000","s4one":"\u0001\u0000\u0000\u0000","b4big":"����","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "\u0001\u0000\u0000\u0000",
@@ -11773,11 +11773,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "��������",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"��������","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
@@ -11812,11 +11812,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "����������������",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "string_json", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"����������������","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
@@ -11851,11 +11851,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -11890,11 +11890,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -11929,11 +11929,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -11968,11 +11968,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "F3 F2 F1 F0",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"01 00 00 00","s4one":"\u0001\u0000\u0000\u0000","b4big":"F3 F2 F1 F0","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "01 00 00 00",
@@ -12007,11 +12007,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -12046,11 +12046,11 @@
       "s16one": "00000000-0000-0000-0000-000000000001",
       "b16big": "f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff",
       "s16big": "f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff",
-      "info": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "uuid", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00000000-0000-0000-0000-000000000001","s16one":"00000000-0000-0000-0000-000000000001","b16big":"f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff","s16big":"f0f1f2f3-f4f5-f6f7-f8f9-fafbfcfdfeff",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00000000-0000-0000-0000-000000000001",
@@ -12085,11 +12085,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -12124,11 +12124,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -12163,11 +12163,11 @@
       "s2one": 256,
       "b2big": 61936,
       "s2big": 61936,
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":256,"s2one":256,"b2big":61936,"s2big":61936,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": 256,
@@ -12202,11 +12202,11 @@
       "s4one": "\u0001\u0000\u0000\u0000",
       "b4big": "F3 F2 F1 F0",
       "s4big": "����",
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"01 00 00 00","s4one":"\u0001\u0000\u0000\u0000","b4big":"F3 F2 F1 F0","s4big":"����",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "01 00 00 00",
@@ -12241,11 +12241,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -12280,11 +12280,11 @@
       "s16one": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
       "b16big": "F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF",
       "s16big": "����������������",
-      "info": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "port", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01","s16one":"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001","b16big":"F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF","s16big":"����������������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01",
@@ -12319,11 +12319,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -12358,11 +12358,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -12397,11 +12397,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -12436,11 +12436,11 @@
       "s4one": "1.0.0.0",
       "b4big": "243.242.241.240",
       "s4big": "243.242.241.240",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"1.0.0.0","s4one":"1.0.0.0","b4big":"243.242.241.240","s4big":"243.242.241.240",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "1.0.0.0",
@@ -12475,11 +12475,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -12514,11 +12514,11 @@
       "s16one": "::1",
       "b16big": "f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
       "s16big": "f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"::1","s16one":"::1","b16big":"f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff","s16big":"f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "::1",
@@ -12553,11 +12553,11 @@
       "s0one": null,
       "b0big": null,
       "s0big": null,
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b0one":null,"s0one":null,"b0big":null,"s0big":null,
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b0one": null,
@@ -12592,11 +12592,11 @@
       "s1one": "\u0001",
       "b1big": "F0",
       "s1big": "�",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b1one":"01","s1one":"\u0001","b1big":"F0","s1big":"�",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b1one": "01",
@@ -12631,11 +12631,11 @@
       "s2one": "\u0001\u0000",
       "b2big": "F1 F0",
       "s2big": "��",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b2one":"01 00","s2one":"\u0001\u0000","b2big":"F1 F0","s2big":"��",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b2one": "01 00",
@@ -12670,11 +12670,11 @@
       "s4one": "1.0.0.0",
       "b4big": "243.242.241.240",
       "s4big": "243.242.241.240",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b4one":"1.0.0.0","s4one":"1.0.0.0","b4big":"243.242.241.240","s4big":"243.242.241.240",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b4one": "1.0.0.0",
@@ -12709,11 +12709,11 @@
       "s8one": "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "b8big": "F7 F6 F5 F4 F3 F2 F1 F0",
       "s8big": "��������",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b8one":"01 00 00 00 00 00 00 00","s8one":"\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000","b8big":"F7 F6 F5 F4 F3 F2 F1 F0","s8big":"��������",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b8one": "01 00 00 00 00 00 00 00",
@@ -12748,11 +12748,11 @@
       "s16one": "::1",
       "b16big": "f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
       "s16big": "f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
-      "info": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
+      "meta": { "provider": "TestProviderDyn", "event": "ip_address_obsolete", "level": 5, "keyword": "0x1", "flags": "0x7" }
     },
     "AppendJsonItem1": {
       "b16one":"::1","s16one":"::1","b16big":"f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff","s16big":"f0f1:f2f3:f4f5:f6f7:f8f9:fafb:fcfd:feff",
-      "info": { "keyword":1 }
+      "meta": { "keyword":1 }
     },
     "MoveNext": {
       "b16one": "::1",

--- a/Provider/README.md
+++ b/Provider/README.md
@@ -163,7 +163,7 @@ provider.Dispose();
 
 ## Changelog
 
-### 0.2.0 (TBD)
+### 0.2.0 (2024-06-19)
 
 - Add support for `BinaryLength16Char8` encoding.
 

--- a/Types/README.md
+++ b/Types/README.md
@@ -277,7 +277,7 @@ project. Feedback and contributions are welcome.
 
 ## Changelog
 
-### 0.2.0 (TBD)
+### 0.2.0 (2024-06-19)
 
 - Renamed extension method `BaseEncoding` to `WithoutFlags` for
   `EventHeaderFieldEncoding` and `EventHeaderFieldFormat`.


### PR DESCRIPTION
- Bump VersionPrefix to 0.2.0.
- Set README release date for 0.2.0 to 2024-06-19.
- Other minor README updates.
- Change interceptor-based tests to use "meta" suffix instead of "info".