### PR TITLE
Update SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.102",
     "rollForward": "latestFeature"
   },
   "test": {


### PR DESCRIPTION
ADO build pipelines require the exact patch version, and do not ever roll forward.